### PR TITLE
Resolve GitHub issue 12

### DIFF
--- a/src/lib/api/products.ts
+++ b/src/lib/api/products.ts
@@ -170,12 +170,12 @@ export async function createParty(partyData: Omit<PartyProduct, 'id' | 'createdA
  */
 export async function updateParty(partyId: string, partyData: Partial<PartyProduct>): Promise<PartyProduct> {
   try {
-    const response = await fetch('/api/parties', {
+    const response = await fetch(`/api/parties/${partyId}`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ id: partyId, ...partyData }),
+      body: JSON.stringify(partyData),
     });
 
     if (!response.ok) {
@@ -196,7 +196,7 @@ export async function updateParty(partyId: string, partyData: Partial<PartyProdu
  */
 export async function deleteParty(partyId: string): Promise<void> {
   try {
-    const response = await fetch(`/api/parties?id=${partyId}`, {
+    const response = await fetch(`/api/parties/${partyId}`, {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
The updateParty and deleteParty functions were calling the wrong API endpoints:
- updateParty was calling `/api/parties` instead of `/api/parties/{id}`
- deleteParty was calling `/api/parties?id={id}` instead of `/api/parties/{id}`

Since the PUT and DELETE handlers are defined in the [id] route file, these operations were failing silently. This fix ensures the API client calls the correct dynamic route endpoints.

Fixes #12