### PR TITLE
Resolve GitHub issue 16

### DIFF
--- a/scripts/disable-promos.sql
+++ b/scripts/disable-promos.sql
@@ -1,14 +1,14 @@
--- Disable Promos Script: Set all promo dates to last year
+-- Disable Promos Script: Disable all promos by setting is_active to false
 -- Run this in Supabase SQL Editor to disable all active promotions
--- This preserves all data but sets dates to 2024 so no promos will be active
+-- This preserves all data and dates - just toggles is_active flag off
 
--- Update all promos to have dates from last year (2024)
+-- Disable all promos by setting is_active = false
+-- This is the most reliable way to disable promos as the isPromoActive()
+-- function checks this flag first before checking dates
 UPDATE public.promos
 SET
-  start_date = start_date - INTERVAL '1 year',
-  end_date = end_date - INTERVAL '1 year',
-  updated_at = NOW()
-WHERE start_date >= '2025-01-01';
+  is_active = false,
+  updated_at = NOW();
 
 -- Verify the update
 SELECT
@@ -19,9 +19,10 @@ SELECT
   end_date,
   is_active,
   CASE
+    WHEN is_active = false THEN 'DISABLED (is_active=false)'
     WHEN CURRENT_DATE BETWEEN start_date AND end_date THEN 'ACTIVE NOW'
     WHEN CURRENT_DATE < start_date THEN 'SCHEDULED'
-    ELSE 'EXPIRED (disabled)'
+    ELSE 'EXPIRED'
   END as status
 FROM public.promos
 ORDER BY start_date;

--- a/src/lib/utils/promoConstants.ts
+++ b/src/lib/utils/promoConstants.ts
@@ -6,7 +6,7 @@
 
 import { PromoSpecial } from "./promoHelpers";
 
-export const PROMO_VERSION = "v3_nov11_2025"; // Update this to force reload of new promo codes
+export const PROMO_VERSION = "v4_dec10_2025_disabled"; // Update this to force reload of new promo codes
 
 export const INITIAL_PROMOS: PromoSpecial[] = [
     {
@@ -18,7 +18,7 @@ export const INITIAL_PROMOS: PromoSpecial[] = [
         description: "Coming soon!  Bee one of the first!",
         stripeCouponCode: "EARLYBEE20",
         bannerStyle: "honeycomb",
-        isActive: true,
+        isActive: false, // Disabled - promo data preserved for future use
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
     },
@@ -31,7 +31,7 @@ export const INITIAL_PROMOS: PromoSpecial[] = [
         description: "Black Friday Deal! (Thanksgiving)",
         stripeCouponCode: "BLACKFRIDAY30",
         bannerStyle: "bold-stripes",
-        isActive: true,
+        isActive: false, // Disabled - promo data preserved for future use
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
     },
@@ -44,7 +44,7 @@ export const INITIAL_PROMOS: PromoSpecial[] = [
         description: "Cyber Monday!",
         stripeCouponCode: "CYBERMONDAY40",
         bannerStyle: "gradient-wave",
-        isActive: true,
+        isActive: false, // Disabled - promo data preserved for future use
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
     },
@@ -57,7 +57,7 @@ export const INITIAL_PROMOS: PromoSpecial[] = [
         description: "Warm up with winter special!",
         stripeCouponCode: "WINTERSPECIAL15",
         bannerStyle: "honeycomb",
-        isActive: true,
+        isActive: false, // Disabled - promo data preserved for future use
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
     },
@@ -70,7 +70,7 @@ export const INITIAL_PROMOS: PromoSpecial[] = [
         description: "Merry Christmas this week only!",
         stripeCouponCode: "XMASSGIFT25",
         bannerStyle: "confetti",
-        isActive: true,
+        isActive: false, // Disabled - promo data preserved for future use
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
     },
@@ -83,7 +83,7 @@ export const INITIAL_PROMOS: PromoSpecial[] = [
         description: "2 Day New Years Special",
         stripeCouponCode: "NEWYEARS30",
         bannerStyle: "confetti",
-        isActive: true,
+        isActive: false, // Disabled - promo data preserved for future use
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
     },
@@ -96,7 +96,7 @@ export const INITIAL_PROMOS: PromoSpecial[] = [
         description: "Special to leave running for 1st 3 months Opening",
         stripeCouponCode: "GRANDOPEN10",
         bannerStyle: "honeycomb",
-        isActive: true,
+        isActive: false, // Disabled - promo data preserved for future use
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
     },


### PR DESCRIPTION
- Set isActive: false on all hardcoded promos in promoConstants.ts
- Update PROMO_VERSION to force localStorage refresh
- Update disable-promos.sql to set is_active = false instead of date shifting

The promos were still appearing despite date resets because:
1. Pricing.tsx uses getPromosFromStorage() which falls back to INITIAL_PROMOS
2. Setting isActive: false is more reliable than date manipulation

Promos are preserved for future use - just toggle isActive back to true when ready.

Fixes #16