### PR TITLE
Resolve GitHub issue 24

### DIFF
--- a/src/app/api/newsletter/route.ts
+++ b/src/app/api/newsletter/route.ts
@@ -1,73 +1,61 @@
-import { NextRequest, NextResponse } from 'next/server'
+/**
+ * API Route: Newsletter Subscription
+ * POST - Subscribe to newsletter and store in database
+ */
 
-interface NewsletterSignupData {
-  name: string
-  email: string
-}
+import { NextRequest, NextResponse } from 'next/server';
+import { subscribeToNewsletter } from '@/lib/services/newsletter';
+import { logger } from '@/lib/logger';
+import { z } from 'zod';
+
+const newsletterSchema = z.object({
+  name: z.string().optional(),
+  email: z.string().email('Invalid email format'),
+  source: z.enum(['website', 'signup', 'login', 'party_booking', 'pre_register']).optional(),
+});
 
 export async function POST(request: NextRequest) {
   try {
-    const data: NewsletterSignupData = await request.json()
-    
-    // Validate required fields
-    if (!data.name || !data.email) {
+    const body = await request.json();
+
+    // Validate request body
+    const validationResult = newsletterSchema.safeParse(body);
+    if (!validationResult.success) {
+      const errorMessages = validationResult.error.issues.map((issue) => issue.message).join(', ');
       return NextResponse.json(
-        { error: 'Name and email are required' },
+        { error: errorMessages },
         { status: 400 }
-      )
+      );
     }
 
-    // Validate email format
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-    if (!emailRegex.test(data.email)) {
+    const { name, email, source } = validationResult.data;
+
+    // Subscribe to newsletter
+    const result = await subscribeToNewsletter({
+      email,
+      name: name || undefined,
+      source: source || 'website',
+    });
+
+    if (!result.success) {
+      logger.error({ email }, 'Newsletter signup failed');
       return NextResponse.json(
-        { error: 'Invalid email format' },
-        { status: 400 }
-      )
+        { error: 'Failed to process newsletter signup' },
+        { status: 500 }
+      );
     }
 
-    // Create email content
-    const emailSubject = 'New Newsletter Signup - Busy Bees'
-    const emailBody = `
-New newsletter signup from Busy Bees website:
-
-Name: ${data.name}
-Email: ${data.email}
-
----
-Please add this contact to the Busy Bees newsletter list.
-Signed up at: ${new Date().toLocaleString()}
-`
-
-    console.log('📧 New newsletter signup:')
-    console.log('To: info@busybeesipc.com')
-    console.log('Subject:', emailSubject)
-    console.log('Body:', emailBody)
-    
-    // TODO: Replace with actual email sending service (SendGrid, Nodemailer, etc.)
-    // You might also want to integrate with newsletter services like Mailchimp, ConvertKit, etc.
-    // await sendEmail({
-    //   to: 'info@busybeesipc.com',
-    //   subject: emailSubject,
-    //   body: emailBody,
-    //   replyTo: data.email
-    // })
-    
-    // await addToNewsletterList({
-    //   name: data.name,
-    //   email: data.email
-    // })
+    logger.info({ email, name, isNew: result.isNew }, 'Newsletter signup processed');
 
     return NextResponse.json({
       success: true,
-      message: 'Thank you for joining our newsletter! Welcome to the Busy Bees family.'
-    })
-
+      message: 'Thank you for joining our newsletter! Welcome to the Busy Bees family.',
+    });
   } catch (error) {
-    console.error('Newsletter signup error:', error)
+    logger.error({ error }, 'Newsletter signup error');
     return NextResponse.json(
       { error: 'Failed to process newsletter signup' },
       { status: 500 }
-    )
+    );
   }
 }

--- a/src/app/api/pre-register/route.ts
+++ b/src/app/api/pre-register/route.ts
@@ -9,6 +9,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { logger } from '@/lib/logger';
+import { subscribeToNewsletter } from '@/lib/services/newsletter';
 import { z } from 'zod';
 
 // Child schema for validation
@@ -56,7 +57,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { parentName, email, phone, children } = validationResult.data;
+    const { parentName, email, phone, children, marketingOptIn } = validationResult.data;
 
     // Clean phone number for storage (remove formatting)
     const cleanPhone = phone.replace(/[^\d]/g, '');
@@ -164,6 +165,15 @@ export async function POST(request: NextRequest) {
       } else {
         logger.info({ customerId, childCount: newChildren.length }, 'Added children to pre-registration');
       }
+    }
+
+    // Subscribe to newsletter if marketing opt-in is enabled (defaults to true)
+    if (marketingOptIn !== false) {
+      await subscribeToNewsletter({
+        email,
+        name: parentName,
+        source: 'pre_register',
+      });
     }
 
     return NextResponse.json({

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -6,6 +6,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getStripeClient } from '@/lib/stripe/client';
 import { createAdminClient } from '@/lib/supabase/server';
+import { subscribeToNewsletter } from '@/lib/services/newsletter';
 import Stripe from 'stripe';
 
 // This is important for Next.js to treat this as raw body
@@ -178,6 +179,14 @@ async function handleCheckoutSessionCompleted(session: Stripe.Checkout.Session) 
     console.error('Error creating purchase:', error);
   } else {
     console.log('Purchase created successfully for customer:', customer_id);
+  }
+
+  // Auto-subscribe to newsletter for party bookings
+  if (purchase_type === 'party_package' && session.customer_email) {
+    await subscribeToNewsletter({
+      email: session.customer_email,
+      source: 'party_booking',
+    });
   }
 }
 

--- a/src/app/customer/login/page.tsx
+++ b/src/app/customer/login/page.tsx
@@ -26,6 +26,19 @@ export default function CustomerLoginPage() {
 
     try {
       await signIn(email, password);
+
+      // Auto-subscribe to newsletter on login (fire and forget)
+      fetch('/api/newsletter', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          source: 'login',
+        }),
+      }).catch(() => {
+        // Silently fail - newsletter subscription is optional
+      });
+
       router.push('/customer/dashboard');
     } catch (err) {
       console.error('Login error:', err);

--- a/src/app/customer/signup/page.tsx
+++ b/src/app/customer/signup/page.tsx
@@ -84,6 +84,19 @@ export default function CustomerSignupPage() {
         role: 'customer',
       });
 
+      // Auto-subscribe to newsletter (fire and forget)
+      fetch('/api/newsletter', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: formData.name,
+          email: formData.email,
+          source: 'signup',
+        }),
+      }).catch(() => {
+        // Silently fail - newsletter subscription is optional
+      });
+
       setSuccess(true);
       // Redirect to verify email page
       setTimeout(() => {

--- a/src/lib/services/newsletter.ts
+++ b/src/lib/services/newsletter.ts
@@ -1,0 +1,172 @@
+/**
+ * Newsletter Service
+ * Handles newsletter subscription operations
+ */
+
+import { createAdminClient } from '@/lib/supabase/server';
+import { logger } from '@/lib/logger';
+
+// Valid sources for newsletter subscriptions
+export type NewsletterSource = 'website' | 'signup' | 'login' | 'party_booking' | 'pre_register';
+
+interface SubscribeOptions {
+  email: string;
+  name?: string;
+  source: NewsletterSource;
+}
+
+interface SubscribeResult {
+  success: boolean;
+  isNew: boolean;
+  message: string;
+}
+
+/**
+ * Subscribe an email to the newsletter
+ * Uses upsert to handle existing subscribers gracefully
+ */
+export async function subscribeToNewsletter(options: SubscribeOptions): Promise<SubscribeResult> {
+  const { email, name, source } = options;
+  const normalizedEmail = email.toLowerCase().trim();
+
+  const supabase = createAdminClient();
+
+  try {
+    // Check if subscriber already exists
+    const { data: existing } = await supabase
+      .from('newsletter_subscribers')
+      .select('id, is_active')
+      .eq('email', normalizedEmail)
+      .single();
+
+    if (existing) {
+      // Subscriber exists
+      if (existing.is_active) {
+        logger.info({ email: normalizedEmail, source }, 'Email already subscribed to newsletter');
+        return {
+          success: true,
+          isNew: false,
+          message: 'Already subscribed to newsletter',
+        };
+      }
+
+      // Reactivate subscription
+      const { error: updateError } = await supabase
+        .from('newsletter_subscribers')
+        .update({
+          is_active: true,
+          name: name || undefined,
+          unsubscribed_at: null,
+        })
+        .eq('id', existing.id);
+
+      if (updateError) {
+        logger.error({ error: updateError, email: normalizedEmail }, 'Failed to reactivate newsletter subscription');
+        return {
+          success: false,
+          isNew: false,
+          message: 'Failed to reactivate subscription',
+        };
+      }
+
+      logger.info({ email: normalizedEmail, source }, 'Reactivated newsletter subscription');
+      return {
+        success: true,
+        isNew: false,
+        message: 'Subscription reactivated',
+      };
+    }
+
+    // Create new subscription
+    const { error: insertError } = await supabase
+      .from('newsletter_subscribers')
+      .insert({
+        email: normalizedEmail,
+        name: name || null,
+        source,
+        is_active: true,
+      });
+
+    if (insertError) {
+      // Handle unique constraint violation (race condition)
+      if (insertError.code === '23505') {
+        logger.info({ email: normalizedEmail, source }, 'Email already subscribed (race condition)');
+        return {
+          success: true,
+          isNew: false,
+          message: 'Already subscribed to newsletter',
+        };
+      }
+
+      logger.error({ error: insertError, email: normalizedEmail }, 'Failed to create newsletter subscription');
+      return {
+        success: false,
+        isNew: false,
+        message: 'Failed to subscribe',
+      };
+    }
+
+    logger.info({ email: normalizedEmail, source, name }, 'New newsletter subscription created');
+    return {
+      success: true,
+      isNew: true,
+      message: 'Successfully subscribed to newsletter',
+    };
+  } catch (error) {
+    logger.error({ error, email: normalizedEmail }, 'Newsletter subscription error');
+    return {
+      success: false,
+      isNew: false,
+      message: 'An error occurred while subscribing',
+    };
+  }
+}
+
+/**
+ * Unsubscribe an email from the newsletter
+ */
+export async function unsubscribeFromNewsletter(email: string): Promise<boolean> {
+  const normalizedEmail = email.toLowerCase().trim();
+  const supabase = createAdminClient();
+
+  try {
+    const { error } = await supabase
+      .from('newsletter_subscribers')
+      .update({
+        is_active: false,
+        unsubscribed_at: new Date().toISOString(),
+      })
+      .eq('email', normalizedEmail);
+
+    if (error) {
+      logger.error({ error, email: normalizedEmail }, 'Failed to unsubscribe from newsletter');
+      return false;
+    }
+
+    logger.info({ email: normalizedEmail }, 'Unsubscribed from newsletter');
+    return true;
+  } catch (error) {
+    logger.error({ error, email: normalizedEmail }, 'Newsletter unsubscribe error');
+    return false;
+  }
+}
+
+/**
+ * Check if an email is subscribed to the newsletter
+ */
+export async function isSubscribed(email: string): Promise<boolean> {
+  const normalizedEmail = email.toLowerCase().trim();
+  const supabase = createAdminClient();
+
+  try {
+    const { data } = await supabase
+      .from('newsletter_subscribers')
+      .select('is_active')
+      .eq('email', normalizedEmail)
+      .single();
+
+    return data?.is_active ?? false;
+  } catch {
+    return false;
+  }
+}

--- a/supabase/migrations/007_add_newsletter_subscribers.sql
+++ b/supabase/migrations/007_add_newsletter_subscribers.sql
@@ -1,0 +1,72 @@
+-- ==================== NEWSLETTER SUBSCRIBERS TABLE ====================
+
+-- Newsletter subscribers table for storing email signups
+CREATE TABLE public.newsletter_subscribers (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email TEXT NOT NULL UNIQUE,
+  name TEXT,
+  source TEXT NOT NULL DEFAULT 'website', -- website, signup, login, party_booking, pre_register
+  subscribed_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  is_active BOOLEAN DEFAULT TRUE,
+  unsubscribed_at TIMESTAMP WITH TIME ZONE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Index for email lookups
+CREATE INDEX idx_newsletter_subscribers_email ON public.newsletter_subscribers(email);
+CREATE INDEX idx_newsletter_subscribers_active ON public.newsletter_subscribers(is_active);
+CREATE INDEX idx_newsletter_subscribers_source ON public.newsletter_subscribers(source);
+
+-- Auto-update trigger
+CREATE TRIGGER update_newsletter_subscribers_updated_at
+  BEFORE UPDATE ON public.newsletter_subscribers
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- ==================== RLS POLICIES ====================
+
+-- Enable RLS on newsletter_subscribers
+ALTER TABLE public.newsletter_subscribers ENABLE ROW LEVEL SECURITY;
+
+-- Allow public insert (anyone can subscribe)
+CREATE POLICY "Anyone can subscribe to newsletter"
+  ON public.newsletter_subscribers
+  FOR INSERT
+  TO public
+  WITH CHECK (true);
+
+-- Only staff/admin can view subscribers
+CREATE POLICY "Staff and admin can view subscribers"
+  ON public.newsletter_subscribers
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.users
+      WHERE users.id = auth.uid()
+      AND users.role IN ('staff', 'admin')
+    )
+  );
+
+-- Only staff/admin can update subscribers
+CREATE POLICY "Staff and admin can update subscribers"
+  ON public.newsletter_subscribers
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.users
+      WHERE users.id = auth.uid()
+      AND users.role IN ('staff', 'admin')
+    )
+  );
+
+-- Only admin can delete subscribers
+CREATE POLICY "Admin can delete subscribers"
+  ON public.newsletter_subscribers
+  FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.users
+      WHERE users.id = auth.uid()
+      AND users.role = 'admin'
+    )
+  );


### PR DESCRIPTION
Store newsletter contacts in database when people sign up. Auto-add people to newsletter when they:
- Sign up for an account
- Log in to their account
- Pre-register for Grand Opening (uses marketingOptIn)
- Book a party through Stripe checkout

Changes:
- Add newsletter_subscribers table migration with RLS policies
- Create newsletter service for reusable subscription logic
- Update newsletter API to store subscribers in database
- Add auto-subscribe on customer signup and login
- Update pre-register to subscribe when marketingOptIn is true
- Update Stripe webhook to subscribe on party booking

Closes #24