### PR TITLE
📝 Update FAQ party package text to clarify 20 kid max

### DIFF
--- a/src/components/info/FAQ.tsx
+++ b/src/components/info/FAQ.tsx
@@ -62,7 +62,7 @@ const faqs = [
       },
       {
         question: 'What if I have more than 15 children?',
-        answer: 'No problem! Additional children are $15 each beyond the 15 included in both party packages. Just let us know your final headcount when you book.'
+        answer: 'Our packages include 15 kids, however we can accommodate up to 20 kids for each party. Each additional child over the included 15 is an additional $15/child.'
       }
     ]
   },


### PR DESCRIPTION
Updates the FAQ answer about party sizes to specify that packages
include 15 kids with capacity for up to 20, at $15 per additional child.

Resolves #52