### PR TITLE
🐛 Fix contact form failure by adding database storage

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { sendContactFormEmail } from '@/lib/email/resend'
+import { saveContactSubmission, updateEmailStatus } from '@/lib/services/contact'
 import { logger } from '@/lib/logger'
 
 interface ContactFormData {
@@ -31,8 +32,8 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    // Send email to business
-    const result = await sendContactFormEmail({
+    // STEP 1: Save to database first (primary storage - ensures no data loss)
+    const saveResult = await saveContactSubmission({
       name: data.name,
       email: data.email,
       phone: data.phone,
@@ -40,19 +41,46 @@ export async function POST(request: NextRequest) {
       message: data.message,
     })
 
-    if (!result.success) {
+    if (!saveResult.success) {
       logger.error(
-        { error: result.error, email: data.email },
-        'Failed to send contact form email'
+        { error: saveResult.error, email: data.email },
+        'Failed to save contact form submission'
       )
       return NextResponse.json(
-        { error: 'Failed to send message. Please try again or email us directly at info@busybeesipc.com' },
+        { error: 'Failed to process your message. Please try again or email us directly at info@busybeesipc.com' },
         { status: 500 }
       )
     }
 
+    // STEP 2: Attempt to send email notification (best effort - non-blocking)
+    const emailResult = await sendContactFormEmail({
+      name: data.name,
+      email: data.email,
+      phone: data.phone,
+      userType: data.userType,
+      message: data.message,
+    })
+
+    // Update email status in database (fire and forget)
+    if (saveResult.submissionId) {
+      void updateEmailStatus(
+        saveResult.submissionId,
+        emailResult.success,
+        emailResult.error
+      )
+    }
+
+    if (!emailResult.success) {
+      // Log the email failure but don't fail the request
+      // The submission is already saved in the database
+      logger.warn(
+        { error: emailResult.error, email: data.email, submissionId: saveResult.submissionId },
+        'Email notification failed but contact form was saved'
+      )
+    }
+
     logger.info(
-      { email: data.email, userType: data.userType },
+      { email: data.email, userType: data.userType, submissionId: saveResult.submissionId, emailSent: emailResult.success },
       '📧 Contact form submitted successfully'
     )
 

--- a/src/lib/services/contact.ts
+++ b/src/lib/services/contact.ts
@@ -1,0 +1,234 @@
+/**
+ * Contact Service
+ * Handles contact form submission storage and retrieval
+ */
+
+import { createAdminClient, createClient } from '@/lib/supabase/server';
+import { logger } from '@/lib/logger';
+import { Database } from '@/lib/supabase/database.types';
+
+// Database types
+type ContactSubmission = Database['public']['Tables']['contact_submissions']['Row'];
+type ContactSubmissionInsert = Database['public']['Tables']['contact_submissions']['Insert'];
+
+export interface ContactSubmissionData {
+  id: string;
+  name: string;
+  email: string;
+  phone: string | null;
+  userType: string;
+  message: string;
+  emailSent: boolean;
+  emailError: string | null;
+  submittedAt: string;
+  createdAt: string;
+}
+
+interface SaveContactOptions {
+  name: string;
+  email: string;
+  phone?: string;
+  userType: string;
+  message: string;
+}
+
+interface SaveContactResult {
+  success: boolean;
+  submissionId?: string;
+  error?: string;
+}
+
+/**
+ * Convert database row to frontend format
+ */
+function toContactData(row: ContactSubmission): ContactSubmissionData {
+  return {
+    id: row.id,
+    name: row.name,
+    email: row.email,
+    phone: row.phone,
+    userType: row.user_type,
+    message: row.message,
+    emailSent: row.email_sent,
+    emailError: row.email_error,
+    submittedAt: row.submitted_at,
+    createdAt: row.created_at,
+  };
+}
+
+/**
+ * Save a contact form submission to the database
+ * This is the primary storage - email sending is secondary
+ */
+export async function saveContactSubmission(options: SaveContactOptions): Promise<SaveContactResult> {
+  const { name, email, phone, userType, message } = options;
+  const normalizedEmail = email.toLowerCase().trim();
+
+  const supabase = createAdminClient();
+
+  try {
+    const insertData: ContactSubmissionInsert = {
+      name: name.trim(),
+      email: normalizedEmail,
+      phone: phone?.trim() || null,
+      user_type: userType,
+      message: message.trim(),
+      email_sent: false,
+    };
+
+    const { data, error } = await supabase
+      .from('contact_submissions')
+      .insert(insertData)
+      .select('id')
+      .single();
+
+    if (error) {
+      logger.error({ error, email: normalizedEmail }, 'Failed to save contact submission');
+      return {
+        success: false,
+        error: 'Failed to save submission',
+      };
+    }
+
+    logger.info(
+      { submissionId: data.id, email: normalizedEmail, userType },
+      '📝 Contact form submission saved'
+    );
+
+    return {
+      success: true,
+      submissionId: data.id,
+    };
+  } catch (error) {
+    logger.error({ error, email: normalizedEmail }, 'Contact submission save error');
+    return {
+      success: false,
+      error: 'An error occurred while saving submission',
+    };
+  }
+}
+
+/**
+ * Update email status for a contact submission
+ */
+export async function updateEmailStatus(
+  submissionId: string,
+  emailSent: boolean,
+  emailError?: string
+): Promise<boolean> {
+  const supabase = createAdminClient();
+
+  try {
+    const { error } = await supabase
+      .from('contact_submissions')
+      .update({
+        email_sent: emailSent,
+        email_error: emailError || null,
+      })
+      .eq('id', submissionId);
+
+    if (error) {
+      logger.error({ error, submissionId }, 'Failed to update email status');
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    logger.error({ error, submissionId }, 'Email status update error');
+    return false;
+  }
+}
+
+// ============================================
+// Admin CRUD functions for contact management
+// ============================================
+
+/**
+ * Get all contact submissions
+ */
+export async function getAllContactSubmissions(): Promise<ContactSubmissionData[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('contact_submissions')
+    .select('*')
+    .order('submitted_at', { ascending: false });
+
+  if (error) throw error;
+  return (data || []).map(toContactData);
+}
+
+/**
+ * Get contact submissions that failed to send email
+ */
+export async function getFailedEmailSubmissions(): Promise<ContactSubmissionData[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('contact_submissions')
+    .select('*')
+    .eq('email_sent', false)
+    .order('submitted_at', { ascending: false });
+
+  if (error) throw error;
+  return (data || []).map(toContactData);
+}
+
+/**
+ * Get a single contact submission by ID
+ */
+export async function getContactSubmission(id: string): Promise<ContactSubmissionData | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('contact_submissions')
+    .select('*')
+    .eq('id', id)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') return null; // Not found
+    throw error;
+  }
+  return toContactData(data);
+}
+
+/**
+ * Delete a contact submission (admin only)
+ */
+export async function deleteContactSubmission(id: string): Promise<void> {
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from('contact_submissions')
+    .delete()
+    .eq('id', id);
+
+  if (error) throw error;
+}
+
+/**
+ * Get contact submission statistics
+ */
+export async function getContactStats(): Promise<{
+  total: number;
+  emailSent: number;
+  emailFailed: number;
+}> {
+  const supabase = await createClient();
+
+  const { count: total, error: totalError } = await supabase
+    .from('contact_submissions')
+    .select('*', { count: 'exact', head: true });
+
+  if (totalError) throw totalError;
+
+  const { count: emailSent, error: sentError } = await supabase
+    .from('contact_submissions')
+    .select('*', { count: 'exact', head: true })
+    .eq('email_sent', true);
+
+  if (sentError) throw sentError;
+
+  return {
+    total: total || 0,
+    emailSent: emailSent || 0,
+    emailFailed: (total || 0) - (emailSent || 0),
+  };
+}

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -590,6 +590,47 @@ export interface Database {
           updated_at?: string;
         };
       };
+      contact_submissions: {
+        Row: {
+          id: string;
+          name: string;
+          email: string;
+          phone: string | null;
+          user_type: string;
+          message: string;
+          email_sent: boolean;
+          email_error: string | null;
+          submitted_at: string;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          name: string;
+          email: string;
+          phone?: string | null;
+          user_type: string;
+          message: string;
+          email_sent?: boolean;
+          email_error?: string | null;
+          submitted_at?: string;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          name?: string;
+          email?: string;
+          phone?: string | null;
+          user_type?: string;
+          message?: string;
+          email_sent?: boolean;
+          email_error?: string | null;
+          submitted_at?: string;
+          created_at?: string;
+          updated_at?: string;
+        };
+      };
     };
     Views: {
       [_ in never]: never;

--- a/supabase/migrations/008_create_contact_submissions.sql
+++ b/supabase/migrations/008_create_contact_submissions.sql
@@ -1,0 +1,76 @@
+-- ==================== CONTACT SUBMISSIONS TABLE ====================
+
+-- Contact form submissions table for storing all contact inquiries
+-- This ensures no contact form data is lost even if email service fails
+CREATE TABLE public.contact_submissions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  email TEXT NOT NULL,
+  phone TEXT,
+  user_type TEXT NOT NULL,
+  message TEXT NOT NULL,
+  email_sent BOOLEAN DEFAULT FALSE,
+  email_error TEXT,
+  submitted_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Indexes for efficient queries
+CREATE INDEX idx_contact_submissions_email ON public.contact_submissions(email);
+CREATE INDEX idx_contact_submissions_user_type ON public.contact_submissions(user_type);
+CREATE INDEX idx_contact_submissions_submitted_at ON public.contact_submissions(submitted_at);
+CREATE INDEX idx_contact_submissions_email_sent ON public.contact_submissions(email_sent);
+
+-- Auto-update trigger for updated_at
+CREATE TRIGGER update_contact_submissions_updated_at
+  BEFORE UPDATE ON public.contact_submissions
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- ==================== RLS POLICIES ====================
+
+-- Enable RLS on contact_submissions
+ALTER TABLE public.contact_submissions ENABLE ROW LEVEL SECURITY;
+
+-- Allow public insert (anyone can submit a contact form)
+CREATE POLICY "Anyone can submit contact form"
+  ON public.contact_submissions
+  FOR INSERT
+  TO public
+  WITH CHECK (true);
+
+-- Only staff/admin can view contact submissions
+CREATE POLICY "Staff and admin can view contact submissions"
+  ON public.contact_submissions
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.users
+      WHERE users.id = auth.uid()
+      AND users.role IN ('staff', 'admin')
+    )
+  );
+
+-- Only staff/admin can update contact submissions
+CREATE POLICY "Staff and admin can update contact submissions"
+  ON public.contact_submissions
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.users
+      WHERE users.id = auth.uid()
+      AND users.role IN ('staff', 'admin')
+    )
+  );
+
+-- Only admin can delete contact submissions
+CREATE POLICY "Admin can delete contact submissions"
+  ON public.contact_submissions
+  FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.users
+      WHERE users.id = auth.uid()
+      AND users.role = 'admin'
+    )
+  );


### PR DESCRIPTION
## Summary
- Fix contact form submissions failing when email service is unavailable
- Add persistent database storage for all contact form submissions
- Email notification now best-effort (non-blocking failure)

## Problem
Contact form submissions would fail entirely if the Resend email service was misconfigured or unavailable, resulting in **lost customer inquiries**.

## Solution
Implemented a database-first approach:
1. Save submission to `contact_submissions` table first (guaranteed persistence)
2. Attempt email notification (best effort)
3. Track email delivery status for monitoring

## Changes
| File | Description |
|------|-------------|
| `supabase/migrations/008_create_contact_submissions.sql` | New table with RLS policies |
| `src/lib/services/contact.ts` | New service for DB operations |
| `src/app/api/contact/route.ts` | Updated to save DB first, email second |
| `src/lib/supabase/database.types.ts` | Added TypeScript types |

## Test Plan
- [ ] Run database migration (`supabase db push`)
- [ ] Submit contact form with valid data → should succeed
- [ ] Verify submission appears in `contact_submissions` table
- [ ] Test with Resend disabled → form should still succeed (email_sent=false)

Fixes #56