### PR TITLE
🐛 Fix pre-registration form error by creating dedicated table (#57)

### DIFF
--- a/src/app/api/pre-register/route.ts
+++ b/src/app/api/pre-register/route.ts
@@ -7,7 +7,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createAdminClient } from '@/lib/supabase/server';
 import { logger } from '@/lib/logger';
 import { subscribeToNewsletter } from '@/lib/services/newsletter';
 import { z } from 'zod';
@@ -27,18 +27,11 @@ const preRegisterSchema = z.object({
   marketingOptIn: z.boolean().optional(),
 });
 
-// Type definitions
-interface UserRecord {
+// Type definitions for pre-registration records
+interface PreRegistrationRecord {
   id: string;
-  name?: string;
-  email?: string;
-  phone?: string;
-  role?: string;
-}
-
-interface ChildRecord {
-  name: string;
-  birthdate: string;
+  email: string;
+  phone: string;
 }
 
 export async function POST(request: NextRequest) {
@@ -57,115 +50,96 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { parentName, email, phone, children, marketingOptIn } = validationResult.data;
+    const { parentName, email, children, marketingOptIn } = validationResult.data;
 
     // Clean phone number for storage (remove formatting)
-    const cleanPhone = phone.replace(/[^\d]/g, '');
+    const cleanPhone = validationResult.data.phone.replace(/[^\d]/g, '');
 
-    const supabase = await createClient();
+    // Use admin client to bypass RLS for public pre-registration
+    const supabase = createAdminClient();
 
-    // Check if user already exists by phone number
+    // Check if pre-registration already exists by phone or email
     // Note: Using type assertion due to Supabase client typing issues in this codebase
-    const existingUserResult = await supabase
-      .from('users')
-      .select('id')
-      .eq('phone', cleanPhone)
+    const existingResult = await supabase
+      .from('pre_registrations')
+      .select('id, email, phone')
+      .or(`phone.eq.${cleanPhone},email.eq.${email.toLowerCase()}`)
       .single();
 
-    const existingUser = existingUserResult.data as UserRecord | null;
+    const existing = existingResult.data as PreRegistrationRecord | null;
 
-    let customerId: string;
-
-    if (existingUser) {
-      // User already exists - update their info and add any new children
-      customerId = existingUser.id;
-
-      // Update user info
+    if (existing) {
+      // Update existing pre-registration with new info
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await (supabase.from('users') as any)
+      const { error: updateError } = await (supabase.from('pre_registrations') as any)
         .update({
-          name: parentName,
-          email: email,
+          parent_name: parentName,
+          email: email.toLowerCase(),
+          phone: cleanPhone,
+          children: children,
+          marketing_opt_in: marketingOptIn ?? true,
           updated_at: new Date().toISOString(),
         })
-        .eq('id', customerId);
+        .eq('id', existing.id);
 
-      logger.info({ customerId, email }, 'Updated existing pre-registration');
-    } else {
-      // Create new customer record
-      // Generate a UUID for the new user
-      const newUserId = crypto.randomUUID();
+      if (updateError) {
+        logger.error({ error: updateError, email }, 'Failed to update pre-registration');
+        return NextResponse.json(
+          { error: 'Failed to update registration', details: updateError.message },
+          { status: 500 }
+        );
+      }
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const insertResult = await (supabase.from('users') as any)
-        .insert({
-          id: newUserId,
+      logger.info({ preRegistrationId: existing.id, email }, 'Updated existing pre-registration');
+
+      // Subscribe to newsletter if marketing opt-in is enabled
+      if (marketingOptIn !== false) {
+        await subscribeToNewsletter({
+          email,
           name: parentName,
-          email: email,
-          phone: cleanPhone,
-          role: 'customer',
-        })
-        .select()
-        .single();
-
-      if (insertResult.error) {
-        logger.error({ error: insertResult.error, email }, 'Failed to create pre-registration user');
-        return NextResponse.json(
-          { error: 'Failed to create registration', details: insertResult.error.message },
-          { status: 500 }
-        );
+          source: 'pre_register',
+        });
       }
 
-      const newUser = insertResult.data as UserRecord | null;
-
-      if (!newUser) {
-        logger.error({ email }, 'No user returned after insert');
-        return NextResponse.json(
-          { error: 'Failed to create registration' },
-          { status: 500 }
-        );
-      }
-
-      customerId = newUser.id;
-      logger.info({ customerId, email }, 'Created new pre-registration');
+      return NextResponse.json({
+        success: true,
+        message: 'Pre-registration updated! Your information has been refreshed.',
+        preRegistrationId: existing.id,
+      });
     }
 
-    // Add children
-    const childrenToInsert = children.map(child => ({
-      customer_id: customerId,
-      name: child.name,
-      birthdate: child.birthdate,
-      waiver_signed: false,
-    }));
+    // Create new pre-registration
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const insertResult = await (supabase.from('pre_registrations') as any)
+      .insert({
+        parent_name: parentName,
+        email: email.toLowerCase(),
+        phone: cleanPhone,
+        children: children,
+        marketing_opt_in: marketingOptIn ?? true,
+      })
+      .select('id')
+      .single();
 
-    // Get existing children for this customer
-    const existingChildrenResult = await supabase
-      .from('children')
-      .select('name, birthdate')
-      .eq('customer_id', customerId);
-
-    const existingChildren = (existingChildrenResult.data || []) as ChildRecord[];
-
-    // Filter out children that already exist (same name and birthdate)
-    const existingChildSet = new Set(
-      existingChildren.map(c => `${c.name.toLowerCase()}-${c.birthdate}`)
-    );
-
-    const newChildren = childrenToInsert.filter(
-      child => !existingChildSet.has(`${child.name.toLowerCase()}-${child.birthdate}`)
-    );
-
-    if (newChildren.length > 0) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const childInsertResult = await (supabase.from('children') as any).insert(newChildren);
-
-      if (childInsertResult.error) {
-        logger.error({ error: childInsertResult.error, customerId }, 'Failed to add children');
-        // Don't fail the whole request - user was created successfully
-      } else {
-        logger.info({ customerId, childCount: newChildren.length }, 'Added children to pre-registration');
-      }
+    if (insertResult.error) {
+      logger.error({ error: insertResult.error, email }, 'Failed to create pre-registration');
+      return NextResponse.json(
+        { error: 'Failed to create registration', details: insertResult.error.message },
+        { status: 500 }
+      );
     }
+
+    const newRegistration = insertResult.data as { id: string } | null;
+
+    if (!newRegistration) {
+      logger.error({ email }, 'No pre-registration returned after insert');
+      return NextResponse.json(
+        { error: 'Failed to create registration' },
+        { status: 500 }
+      );
+    }
+
+    logger.info({ preRegistrationId: newRegistration.id, email }, 'Created new pre-registration');
 
     // Subscribe to newsletter if marketing opt-in is enabled (defaults to true)
     if (marketingOptIn !== false) {
@@ -179,7 +153,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({
       success: true,
       message: 'Pre-registration successful! You\'re all set for your visit.',
-      customerId,
+      preRegistrationId: newRegistration.id,
     });
 
   } catch (error) {

--- a/supabase/migrations/009_create_pre_registrations.sql
+++ b/supabase/migrations/009_create_pre_registrations.sql
@@ -1,0 +1,74 @@
+-- ==================== PRE-REGISTRATIONS TABLE ====================
+
+-- Pre-registration submissions table for storing family registrations
+-- This allows families to pre-register before their first visit without needing auth
+-- Data can be linked to actual user accounts later when they sign up
+CREATE TABLE public.pre_registrations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  parent_name TEXT NOT NULL,
+  email TEXT NOT NULL,
+  phone TEXT NOT NULL,
+  children JSONB NOT NULL DEFAULT '[]', -- Array of {name: string, birthdate: string}
+  marketing_opt_in BOOLEAN DEFAULT TRUE,
+  submitted_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Indexes for efficient queries
+CREATE INDEX idx_pre_registrations_email ON public.pre_registrations(email);
+CREATE INDEX idx_pre_registrations_phone ON public.pre_registrations(phone);
+CREATE INDEX idx_pre_registrations_submitted_at ON public.pre_registrations(submitted_at);
+
+-- Auto-update trigger for updated_at
+CREATE TRIGGER update_pre_registrations_updated_at
+  BEFORE UPDATE ON public.pre_registrations
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- ==================== RLS POLICIES ====================
+
+-- Enable RLS on pre_registrations
+ALTER TABLE public.pre_registrations ENABLE ROW LEVEL SECURITY;
+
+-- Allow public insert (anyone can submit a pre-registration)
+CREATE POLICY "Anyone can submit pre-registration"
+  ON public.pre_registrations
+  FOR INSERT
+  TO public
+  WITH CHECK (true);
+
+-- Only staff/admin can view pre-registrations
+CREATE POLICY "Staff and admin can view pre-registrations"
+  ON public.pre_registrations
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.users
+      WHERE users.id = auth.uid()
+      AND users.role IN ('staff', 'admin')
+    )
+  );
+
+-- Only staff/admin can update pre-registrations
+CREATE POLICY "Staff and admin can update pre-registrations"
+  ON public.pre_registrations
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.users
+      WHERE users.id = auth.uid()
+      AND users.role IN ('staff', 'admin')
+    )
+  );
+
+-- Only admin can delete pre-registrations
+CREATE POLICY "Admin can delete pre-registrations"
+  ON public.pre_registrations
+  FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.users
+      WHERE users.id = auth.uid()
+      AND users.role = 'admin'
+    )
+  );


### PR DESCRIPTION
The pre-registration form was failing because the API tried to insert into
the `users` table which has a foreign key constraint requiring a reference
to `auth.users`. Since pre-registration happens before user authentication,
this would always fail.

Solution:
- Created new `pre_registrations` table to store pre-registration data
  independently of authentication
- Updated API route to use the new table with admin client
- Added appropriate RLS policies for security (public insert, staff/admin
  read/update, admin delete)

This follows the same pattern used for contact_submissions (PR #63).