### PR TITLE
💰 Reorder party pricing: Private on top, Semi-Private below

### DIFF
--- a/src/components/parties/PartyOptions.tsx
+++ b/src/components/parties/PartyOptions.tsx
@@ -26,7 +26,7 @@ const partyTypes = [
       'Perfect for younger children',
       'All party essentials included'
     ],
-    priceNote: 'First price listed in packages below'
+    priceNote: 'Second price listed in packages below'
   },
   {
     name: 'Private Party',
@@ -46,7 +46,7 @@ const partyTypes = [
       'Perfect for larger groups',
       'Maximum flexibility and customization'
     ],
-    priceNote: 'Second price listed in packages below'
+    priceNote: 'First price listed in packages below'
   }
 ]
 
@@ -173,9 +173,9 @@ export function PartyOptions() {
                 <h4 className="font-bold text-charcoal-800">Important Pricing Information</h4>
               </div>
               <p className="text-charcoal-600 leading-relaxed">
-                <strong>Please note:</strong> In our party packages below, the <strong>first price listed</strong> reflects our 
-                <strong> semi-private party rate</strong>, and the <strong>second price listed</strong> reflects our 
-                <strong> private party rate</strong>. Choose the experience that works best for your celebration!
+                <strong>Please note:</strong> In our party packages below, the <strong>first price listed</strong> reflects our
+                <strong> private party rate</strong>, and the <strong>second price listed</strong> reflects our
+                <strong> semi-private party rate</strong>. Choose the experience that works best for your celebration!
               </p>
             </CardContent>
           </Card>

--- a/src/components/parties/PartyPackages.tsx
+++ b/src/components/parties/PartyPackages.tsx
@@ -157,12 +157,12 @@ export function PartyPackages() {
                     <div className="text-center mb-8">
                       <div className="space-y-3">
                         <div className="flex justify-between items-center p-3 bg-white/70 rounded-lg">
-                          <span className="font-medium text-charcoal-700">Semi-Private:</span>
-                          <span className="text-2xl font-bold text-charcoal-800">${pkg.semiPrivatePrice}</span>
-                        </div>
-                        <div className="flex justify-between items-center p-3 bg-white/70 rounded-lg">
                           <span className="font-medium text-charcoal-700">Private:</span>
                           <span className="text-2xl font-bold text-charcoal-800">${pkg.privatePrice}</span>
+                        </div>
+                        <div className="flex justify-between items-center p-3 bg-white/70 rounded-lg">
+                          <span className="font-medium text-charcoal-700">Semi-Private:</span>
+                          <span className="text-2xl font-bold text-charcoal-800">${pkg.semiPrivatePrice}</span>
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
Updates the party packages pricing display order to show Private price
first and Semi-Private price second, as requested in issue #18.

Also updates the pricing note descriptions in PartyOptions to reflect
the new order.

Closes #18