### PR TITLE
Resolve GitHub issue 90

### DIFF
--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -15,7 +15,7 @@ interface AuthGuardProps {
   redirectTo?: string;
 }
 
-export function AuthGuard({ children, requireRole, redirectTo = '/auth/login' }: AuthGuardProps) {
+export function AuthGuard({ children, requireRole, redirectTo = '/customer/login' }: AuthGuardProps) {
   const { user, profile, loading } = useUser();
   const router = useRouter();
 


### PR DESCRIPTION
The AuthGuard component was redirecting unauthenticated users to `/auth/login` which doesn't exist. The actual login page is at `/customer/login`. This caused a 404 error when users were redirected after signup or when accessing protected routes while logged out.