### PR TITLE
🐛 Fix party save button not responding in POS admin

### DIFF
--- a/src/components/pos/AdminPanel.tsx
+++ b/src/components/pos/AdminPanel.tsx
@@ -202,6 +202,7 @@ export function AdminPanel({
   // Parties states
   const [showPartyForm, setShowPartyForm] = useState(false);
   const [editingParty, setEditingParty] = useState<PartyProduct | null>(null);
+  const [savingParty, setSavingParty] = useState(false);
   const [partyFormData, setPartyFormData] = useState({
     name: '',
     basePrice: '',
@@ -1549,6 +1550,9 @@ export function AdminPanel({
       return;
     }
 
+    setSavingParty(true);
+    setPartyFormErrors({});
+
     try {
       const processedAddOns = partyFormData.addOns.map(a => ({
         id: a.id || generateId('addon'),
@@ -1582,6 +1586,8 @@ export function AdminPanel({
     } catch (error) {
       console.error('Error saving party:', error);
       setPartyFormErrors({ submit: error instanceof Error ? error.message : 'Failed to save party' });
+    } finally {
+      setSavingParty(false);
     }
   };
 
@@ -1935,6 +1941,13 @@ export function AdminPanel({
                 </div>
               </div>
 
+              {/* Submit Error */}
+              {partyFormErrors.submit && (
+                <div className="p-4 bg-red-50 border border-red-200 rounded-lg">
+                  <p className="text-red-600 text-sm font-medium">{partyFormErrors.submit}</p>
+                </div>
+              )}
+
               {/* Actions */}
               <div className="flex space-x-3 mt-8">
                 <Button
@@ -1945,12 +1958,15 @@ export function AdminPanel({
                   }}
                   variant="outline"
                   className="flex-1"
+                  disabled={savingParty}
                 >
                   Cancel
                 </Button>
                 <Button
                   onClick={handleSaveParty}
                   className="flex-1"
+                  loading={savingParty}
+                  disabled={savingParty}
                 >
                   {editingParty ? '💾 Update Party' : '✨ Create Party'}
                 </Button>


### PR DESCRIPTION
## Summary

Fixes the issue where clicking the "Update Party" or "Create Party" button in the POS admin party editing form resulted in no visible action.

### Root Cause
The party edit form was missing:
1. A loading state to show the user that the save operation was in progress
2. An error display for API errors - errors were being caught and logged to console but never shown to the user

### Changes
- Added `savingParty` state to track when a save operation is in progress
- Save button now shows loading indicator while saving
- Both buttons are disabled during save to prevent double-submission
- API errors are now displayed in a visible red error box above the action buttons
- Previous errors are cleared when starting a new save attempt

## Test Plan
- [ ] Navigate to POS > Parties
- [ ] Click Edit on any party package
- [ ] Modify any field and click "Update Party"
- [ ] Verify the button shows loading state while saving
- [ ] Verify successful save closes the modal and updates the list
- [ ] Test error handling by disconnecting network and attempting save - error should be displayed

Closes #109