### PR TITLE
Follow AI coding config standards

### DIFF
--- a/src/app/api/pos/customers/route.ts
+++ b/src/app/api/pos/customers/route.ts
@@ -1,0 +1,158 @@
+/**
+ * API Route: POS Customers
+ * GET - List all customers with children for POS admin panel
+ *
+ * Uses admin client (service role) to bypass RLS since POS staff
+ * authentication is PIN-based rather than Supabase session-based.
+ */
+
+import { NextResponse } from 'next/server';
+import { createAdminClient } from '@/lib/supabase/server';
+import { logger } from '@/lib/logger';
+
+interface DbChild {
+  id: string;
+  customer_id: string;
+  name: string;
+  birthdate: string;
+  waiver_signed: boolean;
+  waiver_signed_date: string | null;
+  created_at: string;
+}
+
+interface DbUser {
+  id: string;
+  phone: string;
+  name: string;
+  email: string | null;
+  role: string;
+  created_at: string;
+  last_login: string | null;
+}
+
+interface FormattedChild {
+  id: string;
+  name: string;
+  birthdate: string;
+  waiver_signed: boolean;
+  waiver_signed_date: string | null;
+  created_at: string;
+}
+
+/**
+ * Calculate age from birthdate
+ */
+function calculateAge(birthdate: string): number {
+  const birth = new Date(birthdate);
+  const today = new Date();
+  let age = today.getFullYear() - birth.getFullYear();
+  const monthDiff = today.getMonth() - birth.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
+    age--;
+  }
+  return age;
+}
+
+export async function GET() {
+  try {
+    const supabase = createAdminClient();
+
+    // Fetch all customers with their children
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: users, error: usersError } = await (supabase.from('users') as any)
+      .select(`
+        id,
+        phone,
+        name,
+        email,
+        role,
+        created_at,
+        last_login
+      `)
+      .eq('role', 'customer')
+      .order('created_at', { ascending: false });
+
+    if (usersError) {
+      logger.error({ error: usersError }, 'Failed to fetch customers');
+      return NextResponse.json(
+        { error: 'Failed to fetch customers' },
+        { status: 500 }
+      );
+    }
+
+    const typedUsers = users as DbUser[];
+
+    // Fetch all children for these customers
+    const customerIds = typedUsers.map((u) => u.id);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: children, error: childrenError } = await (supabase.from('children') as any)
+      .select('*')
+      .in('customer_id', customerIds);
+
+    if (childrenError) {
+      logger.error({ error: childrenError }, 'Failed to fetch children');
+      // Continue without children rather than failing
+    }
+
+    const typedChildren = (children || []) as DbChild[];
+
+    // Map children to their customers
+    const childrenByCustomer = new Map<string, FormattedChild[]>();
+    for (const child of typedChildren) {
+      const customerId = child.customer_id;
+      if (!childrenByCustomer.has(customerId)) {
+        childrenByCustomer.set(customerId, []);
+      }
+      childrenByCustomer.get(customerId)!.push({
+        id: child.id,
+        name: child.name,
+        birthdate: child.birthdate,
+        waiver_signed: child.waiver_signed,
+        waiver_signed_date: child.waiver_signed_date,
+        created_at: child.created_at,
+      });
+    }
+
+    // Format response to match the AdminPanel expected structure
+    const customers = typedUsers.map((user) => {
+      const userChildren = childrenByCustomer.get(user.id) || [];
+      return {
+        id: user.id,
+        phone: user.phone,
+        name: user.name,
+        email: user.email,
+        children: userChildren.map((child) => ({
+          id: child.id,
+          name: child.name,
+          birthdate: child.birthdate,
+          age: calculateAge(child.birthdate),
+          waiverSigned: child.waiver_signed,
+          waiverSignedDate: child.waiver_signed_date,
+          createdAt: child.created_at,
+        })),
+        purchases: [], // Purchases would need a separate fetch if needed
+        activeSessions: [], // Sessions would need a separate fetch if needed
+        savedCards: [], // Payment methods would need a separate fetch if needed
+        createdAt: user.created_at,
+        lastVisit: user.last_login,
+      };
+    });
+
+    logger.info(
+      { customerCount: customers.length },
+      'POS customers fetched successfully'
+    );
+
+    return NextResponse.json({ customers });
+  } catch (error) {
+    logger.error({ error }, 'POS customers fetch error');
+    return NextResponse.json(
+      {
+        error: 'An unexpected error occurred',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/pos/page.tsx
+++ b/src/app/pos/page.tsx
@@ -780,6 +780,28 @@ export default function POSPage() {
     // All customer data comes from API calls via PhoneLogin
     const [customers, setCustomers] = useState<Customer[]>([]);
 
+    // Fetch customers from database when entering admin mode
+    const fetchCustomers = useCallback(async () => {
+        try {
+            const response = await fetch('/api/pos/customers');
+            if (response.ok) {
+                const data = await response.json();
+                setCustomers(data.customers || []);
+            } else {
+                console.error('Failed to fetch customers:', await response.text());
+            }
+        } catch (error) {
+            console.error('Error fetching customers:', error);
+        }
+    }, []);
+
+    // Fetch customers when entering admin mode
+    useEffect(() => {
+        if (isStaffMode && currentView === "admin") {
+            fetchCustomers();
+        }
+    }, [isStaffMode, currentView, fetchCustomers]);
+
     const handleLogin = (customer: Customer) => {
         setCurrentCustomer(customer);
         setCurrentView("checkin"); // Automatically go to Check In screen


### PR DESCRIPTION
Root cause: The POS admin panel received customers as props, but the customers array was never populated from the database. It was only filled when customers logged in via PhoneLogin during the current session.

Changes:
- Add /api/pos/customers endpoint that uses admin client to fetch all customers with their children from the database
- Update POS page to fetch customers when entering admin mode

This fixes GitHub issue #103 where pre-registered families were not appearing in the Customers view of the admin panel.