### PR TITLE
📝 Update Queen Bee Party description: balloons → decorations

### DIFF
--- a/src/components/info/FAQ.tsx
+++ b/src/components/info/FAQ.tsx
@@ -54,7 +54,7 @@ const faqs = [
       },
       {
         question: 'What\'s included in party packages?',
-        answer: 'Private parties get exclusive use of the party room and play space. All packages include 2 hours of celebration time, tables and chairs, and paper goods. Worker Bee and Queen Bee packages also include pizza and soda. The Queen Bee package adds sheet cake and balloons!'
+        answer: 'Private parties get exclusive use of the party room and play space. All packages include 2 hours of celebration time, tables and chairs, and paper goods. Worker Bee and Queen Bee packages also include pizza and soda. The Queen Bee package adds sheet cake and decorations!'
       },
       {
         question: 'Can I bring my own decorations and cake?',

--- a/src/components/parties/PartyPackageBackdrop.tsx
+++ b/src/components/parties/PartyPackageBackdrop.tsx
@@ -69,7 +69,7 @@ export function PartyPackageBackdrop() {
                   <p className="text-base font-medium text-gray-700">🎉 Exclusive party room</p>
                   <p className="text-base font-medium text-gray-700">🍽️ Paper goods included</p>
                   <p className="text-base font-medium text-gray-700">🍕 Pizza and soda included</p>
-                  <p className="text-base font-medium text-gray-700">🎂 Sheet cake & balloons</p>
+                  <p className="text-base font-medium text-gray-700">🎂 Sheet cake & decorations</p>
                 </div>
               </div>
             </div>

--- a/src/components/parties/PartyPackages.tsx
+++ b/src/components/parties/PartyPackages.tsx
@@ -58,7 +58,7 @@ const partyPackages = [
   },
   {
     name: 'Queen Bee+',
-    description: 'Premium package with pizza, soda, cake and balloons',
+    description: 'Premium package with pizza, soda, cake and decorations',
     icon: Crown,
     color: 'from-pink-200 to-pink-300',
     borderColor: 'border-pink-300',
@@ -74,7 +74,7 @@ const partyPackages = [
       'Pizza for all guests',
       'Soda for all guests',
       'Birthday cake included',
-      'Balloon decorations',
+      'Decorations',
       'Dedicated party host assistance'
     ],
     popular: false


### PR DESCRIPTION
## Summary
- Changes "Sheet Cake and Balloons" to "Sheet cake and decorations" in Queen Bee Party descriptions
- Updated across 3 files for consistency:
  - `PartyPackageBackdrop.tsx` - Party package backdrop display
  - `PartyPackages.tsx` - Package description and features list
  - `FAQ.tsx` - FAQ answer about party packages

Fixes #144

## Test plan
- [ ] Verify Queen Bee party description shows "decorations" instead of "balloons" on party packages page
- [ ] Verify FAQ page shows updated wording
- [ ] Verify party package backdrop displays correctly