### PR TITLE
🐛 Fix party booking calendar timezone off-by-one bug

### DIFF
--- a/src/components/parties/PartyCalendar.tsx
+++ b/src/components/parties/PartyCalendar.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
 import { ChevronLeft, ChevronRight, Calendar, Clock, Users, MapPin } from 'lucide-react';
+import { formatDateToYYYYMMDD } from '@/lib/utils';
 
 export interface PartyBooking {
   id: string;
@@ -54,7 +55,7 @@ const PARTY_TIME_SLOTS = {
 const SAMPLE_BOOKINGS: PartyBooking[] = [
   {
     id: 'booking_1',
-    date: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString().split('T')[0], // 2 days from now
+    date: formatDateToYYYYMMDD(new Date(Date.now() + 2 * 24 * 60 * 60 * 1000)), // 2 days from now
     startTime: '13:00',
     endTime: '15:00',
     duration: 2,
@@ -70,7 +71,7 @@ const SAMPLE_BOOKINGS: PartyBooking[] = [
   },
   {
     id: 'booking_2',
-    date: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString().split('T')[0], // 5 days from now
+    date: formatDateToYYYYMMDD(new Date(Date.now() + 5 * 24 * 60 * 60 * 1000)), // 5 days from now
     startTime: '16:00',
     endTime: '18:00',
     duration: 2,
@@ -86,7 +87,7 @@ const SAMPLE_BOOKINGS: PartyBooking[] = [
   },
   {
     id: 'booking_3',
-    date: new Date(Date.now() + 9 * 24 * 60 * 60 * 1000).toISOString().split('T')[0], // 9 days from now
+    date: formatDateToYYYYMMDD(new Date(Date.now() + 9 * 24 * 60 * 60 * 1000)), // 9 days from now
     startTime: '12:00',
     endTime: '14:00',
     duration: 2,
@@ -102,7 +103,7 @@ const SAMPLE_BOOKINGS: PartyBooking[] = [
   },
   {
     id: 'booking_4',
-    date: new Date(Date.now() + 12 * 24 * 60 * 60 * 1000).toISOString().split('T')[0], // 12 days from now
+    date: formatDateToYYYYMMDD(new Date(Date.now() + 12 * 24 * 60 * 60 * 1000)), // 12 days from now
     startTime: '15:00',
     endTime: '17:00',
     duration: 2,
@@ -151,7 +152,7 @@ export function PartyCalendar({
   };
 
   const getAvailableTimeSlots = (date: Date): TimeSlot[] => {
-    const dateString = date.toISOString().split('T')[0];
+    const dateString = formatDateToYYYYMMDD(date);
     const dayBookings = bookings.filter(b => b.date === dateString && b.status !== 'cancelled');
     
     const slots = isWeekend(date) ? PARTY_TIME_SLOTS.weekend : PARTY_TIME_SLOTS.weekday;
@@ -215,7 +216,7 @@ export function PartyCalendar({
   };
 
   const handleDateClick = (date: Date) => {
-    const dateString = date.toISOString().split('T')[0];
+    const dateString = formatDateToYYYYMMDD(date);
     setSelectedDate(dateString);
   };
 
@@ -230,12 +231,12 @@ export function PartyCalendar({
   };
 
   const getBookingCountForDate = (date: Date) => {
-    const dateString = date.toISOString().split('T')[0];
+    const dateString = formatDateToYYYYMMDD(date);
     return bookings.filter(b => b.date === dateString && b.status !== 'cancelled').length;
   };
 
   const days = getDaysInMonth(currentDate);
-  const today = new Date().toISOString().split('T')[0];
+  const today = formatDateToYYYYMMDD(new Date());
   const upcomingBookings = bookings
     .filter(b => b.date >= today && b.status !== 'cancelled')
     .sort((a, b) => a.date.localeCompare(b.date) || a.startTime.localeCompare(b.startTime))
@@ -306,8 +307,8 @@ export function PartyCalendar({
                   if (!date) {
                     return <div key={index} className="p-3" />;
                   }
-                  
-                  const dateString = date.toISOString().split('T')[0];
+
+                  const dateString = formatDateToYYYYMMDD(date);
                   const isToday = dateString === today;
                   const isSelected = dateString === selectedDate;
                   const isPast = dateString < today;

--- a/src/components/parties/booking-steps/DateTimeStep.tsx
+++ b/src/components/parties/booking-steps/DateTimeStep.tsx
@@ -10,6 +10,7 @@ import {
   isValidBookingDate,
   hasAvailableSlots,
 } from '@/lib/validations/party-booking';
+import { formatDateToYYYYMMDD } from '@/lib/utils';
 import type { BookingFormData } from '../PartyBookingWizard';
 
 interface DateTimeStepProps {
@@ -37,8 +38,8 @@ export function DateTimeStep({ formData, onUpdate, onValidChange }: DateTimeStep
       try {
         const year = currentMonth.getFullYear();
         const month = currentMonth.getMonth();
-        const startDate = new Date(year, month, 1).toISOString().split('T')[0];
-        const endDate = new Date(year, month + 1, 0).toISOString().split('T')[0];
+        const startDate = formatDateToYYYYMMDD(new Date(year, month, 1));
+        const endDate = formatDateToYYYYMMDD(new Date(year, month + 1, 0));
 
         const response = await fetch(
           `/api/party-booking/availability?startDate=${startDate}&endDate=${endDate}`
@@ -97,7 +98,7 @@ export function DateTimeStep({ formData, onUpdate, onValidChange }: DateTimeStep
   };
 
   const handleDateSelect = (date: Date) => {
-    const dateString = date.toISOString().split('T')[0];
+    const dateString = formatDateToYYYYMMDD(date);
     onUpdate({
       partyDate: dateString,
       startTime: '',
@@ -171,7 +172,7 @@ export function DateTimeStep({ formData, onUpdate, onValidChange }: DateTimeStep
                 return <div key={index} className="p-2" />;
               }
 
-              const dateString = date.toISOString().split('T')[0];
+              const dateString = formatDateToYYYYMMDD(date);
               const isToday = date.getTime() === today.getTime();
               const isSelected = dateString === formData.partyDate;
               const isPast = date < today;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -58,6 +58,19 @@ export function getAgeGroupLabel(ageGroup: 'infant' | 'toddler' | 'child'): stri
   return labels[ageGroup]
 }
 
+// Date formatting helpers
+/**
+ * Formats a Date to YYYY-MM-DD string using LOCAL timezone.
+ * This avoids the off-by-one bug caused by toISOString() which converts to UTC.
+ * For example, in Pacific time (UTC-8), Jan 1st local becomes Dec 31st UTC.
+ */
+export function formatDateToYYYYMMDD(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
 // Business hours helpers
 export function isOpen(): boolean {
   const now = new Date()


### PR DESCRIPTION
## Summary

- Fixes the calendar showing dates one day off due to timezone conversion issues
- Adds timezone-safe date formatting utility function
- Updates DateTimeStep.tsx and PartyCalendar.tsx to use local timezone formatting

## Root Cause

The bug was caused by using `date.toISOString().split('T')[0]` to convert local dates to YYYY-MM-DD strings. The `toISOString()` method converts to UTC, so for users west of UTC (e.g., Pacific at UTC-8), local dates were being shifted back a day:

- User selects January 1st (local)
- `toISOString()` converts to UTC, which is December 31st
- Date string becomes "2025-12-31" instead of "2026-01-01"

## Solution

Added a new `formatDateToYYYYMMDD()` utility function that uses local date components:

```typescript
export function formatDateToYYYYMMDD(date: Date): string {
  const year = date.getFullYear();
  const month = String(date.getMonth() + 1).padStart(2, '0');
  const day = String(date.getDate()).padStart(2, '0');
  return `${year}-${month}-${day}`;
}
```

## Files Changed

- `src/lib/utils.ts` - Added `formatDateToYYYYMMDD()` helper function
- `src/components/parties/booking-steps/DateTimeStep.tsx` - Updated to use new date formatting
- `src/components/parties/PartyCalendar.tsx` - Updated to use new date formatting

## Test Plan

- [ ] Verify calendar shows correct dates in user's local timezone
- [ ] Verify date selection stores the correct date
- [ ] Verify time slots align with the selected date
- [ ] Test in a timezone west of UTC (e.g., Pacific Time)

Fixes #139