### PR TITLE
🐛 Fix double Header and Footer on Account pages

### DIFF
--- a/src/app/customer/login/page.tsx
+++ b/src/app/customer/login/page.tsx
@@ -12,8 +12,6 @@ import Link from 'next/link';
 import { Clock } from 'lucide-react';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
-import { Header } from '@/components/layout/Header';
-import { Footer } from '@/components/layout/Footer';
 import { PURCHASING_ENABLED } from '@/lib/feature-flags';
 
 function LoginForm() {
@@ -238,16 +236,12 @@ function LoginForm() {
 
 export default function CustomerLoginPage() {
   return (
-    <div className="min-h-screen flex flex-col">
-      <Header />
-      <Suspense fallback={
-        <div className="flex-1 bg-gradient-to-br from-yellow-50 via-orange-50 to-amber-50 flex items-center justify-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-yellow-500"></div>
-        </div>
-      }>
-        <LoginForm />
-      </Suspense>
-      <Footer />
-    </div>
+    <Suspense fallback={
+      <div className="flex items-center justify-center py-24 bg-gradient-to-br from-yellow-50 via-orange-50 to-amber-50">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-yellow-500"></div>
+      </div>
+    }>
+      <LoginForm />
+    </Suspense>
   );
 }

--- a/src/app/customer/profile/page.tsx
+++ b/src/app/customer/profile/page.tsx
@@ -11,8 +11,6 @@ import { useUser } from '@/hooks/useUser';
 import { createClient } from '@/lib/supabase/client';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
-import { Header } from '@/components/layout/Header';
-import { Footer } from '@/components/layout/Footer';
 import Link from 'next/link';
 
 function ProfileContent() {
@@ -63,20 +61,14 @@ function ProfileContent() {
 
   if (!profile) {
     return (
-      <div className="min-h-screen flex flex-col">
-        <Header />
-        <div className="flex-1 flex items-center justify-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-yellow-500"></div>
-        </div>
-        <Footer />
+      <div className="flex items-center justify-center py-24 bg-gradient-to-br from-yellow-50 via-orange-50 to-amber-50">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-yellow-500"></div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <Header />
-      <div className="flex-1 bg-gradient-to-br from-yellow-50 via-orange-50 to-amber-50 py-8">
+    <div className="bg-gradient-to-br from-yellow-50 via-orange-50 to-amber-50 py-8">
       <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Header */}
         <div className="mb-8">
@@ -218,8 +210,6 @@ function ProfileContent() {
           </div>
         </Card>
       </div>
-      </div>
-      <Footer />
     </div>
   );
 }

--- a/src/app/customer/purchase/page.tsx
+++ b/src/app/customer/purchase/page.tsx
@@ -11,8 +11,6 @@ import { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
-import { Header } from '@/components/layout/Header';
-import { Footer } from '@/components/layout/Footer';
 import { useAuth } from '@/hooks/useAuth';
 import { Loader2, ShoppingCart, AlertCircle, ArrowLeft, CreditCard, CheckCircle } from 'lucide-react';
 
@@ -190,14 +188,10 @@ export default function PurchasePage() {
     router.push('/');
   };
 
-  // Helper to wrap content with layout
+  // Helper to wrap content with consistent styling
   const withLayout = (content: React.ReactNode) => (
-    <div className="min-h-screen flex flex-col">
-      <Header />
-      <div className="flex-1 bg-gradient-to-br from-yellow-50 via-orange-50 to-amber-50 flex items-center justify-center py-12 px-4">
-        {content}
-      </div>
-      <Footer />
+    <div className="bg-gradient-to-br from-yellow-50 via-orange-50 to-amber-50 flex items-center justify-center py-12 px-4">
+      {content}
     </div>
   );
 

--- a/src/app/customer/set-password/page.tsx
+++ b/src/app/customer/set-password/page.tsx
@@ -10,8 +10,6 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
-import { Header } from '@/components/layout/Header';
-import { Footer } from '@/components/layout/Footer';
 
 function SetPasswordForm() {
   const router = useRouter();
@@ -283,16 +281,12 @@ function SetPasswordForm() {
 
 export default function SetPasswordPage() {
   return (
-    <div className="min-h-screen flex flex-col">
-      <Header />
-      <Suspense fallback={
-        <div className="flex-1 bg-gradient-to-br from-yellow-50 via-orange-50 to-amber-50 flex items-center justify-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-yellow-500"></div>
-        </div>
-      }>
-        <SetPasswordForm />
-      </Suspense>
-      <Footer />
-    </div>
+    <Suspense fallback={
+      <div className="flex items-center justify-center py-24 bg-gradient-to-br from-yellow-50 via-orange-50 to-amber-50">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-yellow-500"></div>
+      </div>
+    }>
+      <SetPasswordForm />
+    </Suspense>
   );
 }

--- a/src/app/customer/signup/page.tsx
+++ b/src/app/customer/signup/page.tsx
@@ -12,8 +12,6 @@ import Link from 'next/link';
 import { Clock } from 'lucide-react';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
-import { Header } from '@/components/layout/Header';
-import { Footer } from '@/components/layout/Footer';
 import { PURCHASING_ENABLED } from '@/lib/feature-flags';
 
 function SignupForm() {
@@ -333,16 +331,12 @@ function SignupForm() {
 
 export default function CustomerSignupPage() {
   return (
-    <div className="min-h-screen flex flex-col">
-      <Header />
-      <Suspense fallback={
-        <div className="flex-1 bg-gradient-to-br from-yellow-50 via-orange-50 to-amber-50 flex items-center justify-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-yellow-500"></div>
-        </div>
-      }>
-        <SignupForm />
-      </Suspense>
-      <Footer />
-    </div>
+    <Suspense fallback={
+      <div className="flex items-center justify-center py-24 bg-gradient-to-br from-yellow-50 via-orange-50 to-amber-50">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-yellow-500"></div>
+      </div>
+    }>
+      <SignupForm />
+    </Suspense>
   );
 }

--- a/src/app/customer/verify-email/page.tsx
+++ b/src/app/customer/verify-email/page.tsx
@@ -9,8 +9,6 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
-import { Header } from '@/components/layout/Header';
-import { Footer } from '@/components/layout/Footer';
 import { createClient } from '@/lib/supabase/client';
 
 export default function VerifyEmailPage() {
@@ -81,20 +79,14 @@ export default function VerifyEmailPage() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen flex flex-col">
-        <Header />
-        <div className="flex-1 flex items-center justify-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-yellow-500"></div>
-        </div>
-        <Footer />
+      <div className="flex items-center justify-center py-24 bg-gradient-to-br from-yellow-50 via-orange-50 to-amber-50">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-yellow-500"></div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <Header />
-      <div className="flex-1 bg-gradient-to-br from-yellow-50 via-orange-50 to-amber-50 flex items-center justify-center py-12 px-4">
+    <div className="bg-gradient-to-br from-yellow-50 via-orange-50 to-amber-50 flex items-center justify-center py-12 px-4">
         <div className="max-w-md w-full">
           <Card className="p-8">
             <div className="text-center mb-6">
@@ -168,8 +160,6 @@ export default function VerifyEmailPage() {
           </Card>
         </div>
       </div>
-      <Footer />
-    </div>
   );
 }
 

--- a/src/components/customer/WebMyAccount.tsx
+++ b/src/components/customer/WebMyAccount.tsx
@@ -14,8 +14,6 @@ import { AddPaymentMethodModal } from '@/components/pos/AddPaymentMethodModal';
 import { CountdownTimer } from '@/components/pos/CountdownTimer';
 import { PartySchedulingModal } from '@/components/pos/PartySchedulingModal';
 import { SuccessModal } from '@/components/ui/SuccessModal';
-import { Header } from '@/components/layout/Header';
-import { Footer } from '@/components/layout/Footer';
 import { useUser } from '@/hooks/useUser';
 import { formatCurrency } from '@/lib/utils/productHelpers';
 
@@ -1819,35 +1817,16 @@ function WebMyAccountContent() {
   );
 }
 
-// Loading fallback for Suspense
-function DashboardLoading() {
-  return (
-    <div className="min-h-screen flex flex-col">
-      <Header />
-      <main className="flex-1 flex items-center justify-center py-24 bg-gradient-to-br from-yellow-50 via-orange-50 to-amber-50">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-yellow-500"></div>
-      </main>
-      <Footer />
-    </div>
-  );
-}
-
 // Main export with Suspense boundary for useSearchParams
 export function WebMyAccount() {
   return (
-    <div className="min-h-screen flex flex-col">
-      <Header />
-      <main className="flex-1">
-        <Suspense fallback={
-          <div className="flex items-center justify-center py-24 bg-gradient-to-br from-yellow-50 via-orange-50 to-amber-50">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-yellow-500"></div>
-          </div>
-        }>
-          <WebMyAccountContent />
-        </Suspense>
-      </main>
-      <Footer />
-    </div>
+    <Suspense fallback={
+      <div className="flex items-center justify-center py-24 bg-gradient-to-br from-yellow-50 via-orange-50 to-amber-50">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-yellow-500"></div>
+      </div>
+    }>
+      <WebMyAccountContent />
+    </Suspense>
   );
 }
 


### PR DESCRIPTION
## Summary

- **Fixes**: Double header and footer appearing on customer account pages
- **Root Cause**: Customer layout already wraps pages with `Layout` component (Header/Footer), but individual pages were also rendering their own Header/Footer
- **Solution**: Removed redundant Header/Footer imports and JSX from all affected customer pages

## Changes Made

Removed duplicate Header/Footer from:
- `src/components/customer/WebMyAccount.tsx` (dashboard)
- `src/app/customer/profile/page.tsx`
- `src/app/customer/set-password/page.tsx`
- `src/app/customer/purchase/page.tsx`
- `src/app/customer/signup/page.tsx`
- `src/app/customer/login/page.tsx`
- `src/app/customer/verify-email/page.tsx`

## Test Plan

- [ ] Verify login page shows single Header and Footer
- [ ] Verify signup page shows single Header and Footer
- [ ] Verify dashboard (My Account) shows single Header and Footer
- [ ] Verify profile page shows single Header and Footer
- [ ] Verify set-password page shows single Header and Footer
- [ ] Verify purchase page shows single Header and Footer
- [ ] Verify verify-email page shows single Header and Footer

Closes #133