### PR TITLE
Resolve GitHub issue with multithreading

### DIFF
--- a/src/app/api/purchases/[id]/refund/route.ts
+++ b/src/app/api/purchases/[id]/refund/route.ts
@@ -1,0 +1,176 @@
+/**
+ * API Route: Purchase Refund
+ * POST - Process a refund for a purchase via Stripe
+ *
+ * Note: POS staff access is controlled via PIN at the application level.
+ * This endpoint is only accessible from the admin panel after PIN verification.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createAdminClient } from '@/lib/supabase/server';
+import { getStripeClient } from '@/lib/stripe/client';
+import { logger } from '@/lib/logger';
+import * as Sentry from '@sentry/nextjs';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: purchaseId } = await params;
+
+  const logContext = { purchaseId };
+  logger.info(logContext, '💰 Processing refund request');
+
+  try {
+    const supabase = createAdminClient();
+
+    // 1. Get the purchase from database
+    const { data: purchase, error: fetchError } = await supabase
+      .from('purchases')
+      .select('*')
+      .eq('id', purchaseId)
+      .single();
+
+    if (fetchError || !purchase) {
+      logger.warn({ ...logContext, error: fetchError }, 'Purchase not found');
+      return NextResponse.json(
+        { error: 'Purchase not found' },
+        { status: 404 }
+      );
+    }
+
+    // 2. Check if purchase has a Stripe payment intent
+    const paymentIntentId = purchase.stripe_payment_intent_id;
+
+    if (!paymentIntentId) {
+      logger.warn(logContext, 'No payment intent found for purchase');
+      return NextResponse.json(
+        { error: 'No payment record found for this purchase. It may have been a cash or gift card purchase.' },
+        { status: 400 }
+      );
+    }
+
+    // Skip Stripe refund for gift card purchases (they start with 'giftcard_')
+    if (paymentIntentId.startsWith('giftcard_')) {
+      logger.info(logContext, 'Gift card purchase - marking as refunded without Stripe call');
+
+      // Just update the status in the database
+      const { error: updateError } = await supabase
+        .from('purchases')
+        .update({ status: 'expired' })
+        .eq('id', purchaseId);
+
+      if (updateError) {
+        logger.error({ ...logContext, error: updateError }, 'Failed to update purchase status');
+        throw updateError;
+      }
+
+      return NextResponse.json({
+        success: true,
+        message: 'Gift card purchase marked as refunded',
+        purchaseId,
+      });
+    }
+
+    // 3. Process refund via Stripe
+    const stripe = await getStripeClient();
+
+    logger.info({ ...logContext, paymentIntentId }, 'Creating Stripe refund');
+
+    const refund = await Sentry.startSpan(
+      { op: 'stripe.refund', name: 'Create Refund' },
+      async (span) => {
+        span.setAttribute('payment_intent_id', paymentIntentId);
+        span.setAttribute('purchase_id', purchaseId);
+
+        return stripe.refunds.create({
+          payment_intent: paymentIntentId,
+          reason: 'requested_by_customer',
+          metadata: {
+            purchase_id: purchaseId,
+            customer_id: purchase.customer_id,
+            refund_source: 'pos_admin',
+          },
+        });
+      }
+    );
+
+    logger.info(
+      { ...logContext, refundId: refund.id, refundStatus: refund.status },
+      '✅ Stripe refund created'
+    );
+
+    // 4. Update purchase status in database
+    const { error: updateError } = await supabase
+      .from('purchases')
+      .update({ status: 'expired' })
+      .eq('id', purchaseId);
+
+    if (updateError) {
+      logger.error({ ...logContext, error: updateError }, 'Failed to update purchase status after refund');
+      // The refund was processed, but DB update failed - log to Sentry
+      Sentry.captureException(updateError, {
+        tags: { component: 'api', action: 'refund_db_update' },
+        extra: { purchaseId, refundId: refund.id },
+      });
+      // Still return success since the refund was processed
+    }
+
+    Sentry.addBreadcrumb({
+      category: 'stripe.refund',
+      message: 'Refund processed successfully',
+      level: 'info',
+      data: {
+        purchaseId,
+        refundId: refund.id,
+        amount: refund.amount,
+      },
+    });
+
+    return NextResponse.json({
+      success: true,
+      refundId: refund.id,
+      refundStatus: refund.status,
+      amount: refund.amount / 100, // Convert cents to dollars
+      purchaseId,
+      message: `Refund of $${(refund.amount / 100).toFixed(2)} processed successfully`,
+    });
+  } catch (error) {
+    logger.error({ ...logContext, error }, '❌ Refund processing failed');
+
+    Sentry.captureException(error, {
+      tags: { component: 'api', action: 'process_refund' },
+      extra: { purchaseId },
+    });
+
+    // Handle specific Stripe errors
+    if (error instanceof Error) {
+      const stripeError = error as { type?: string; message?: string; code?: string };
+
+      if (stripeError.type === 'StripeInvalidRequestError') {
+        // Check for common refund errors
+        if (stripeError.code === 'charge_already_refunded') {
+          return NextResponse.json(
+            { error: 'This purchase has already been refunded.' },
+            { status: 400 }
+          );
+        }
+        if (stripeError.code === 'charge_expired_for_refund') {
+          return NextResponse.json(
+            { error: 'This purchase is too old to refund via the original payment method.' },
+            { status: 400 }
+          );
+        }
+        return NextResponse.json(
+          { error: stripeError.message || 'Invalid refund request' },
+          { status: 400 }
+        );
+      }
+    }
+
+    return NextResponse.json(
+      { error: 'Failed to process refund. Please try again or contact support.' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/pos/AdminPanel.tsx
+++ b/src/components/pos/AdminPanel.tsx
@@ -167,6 +167,7 @@ export function AdminPanel({
     products: { total: 0, synced: 0, unsynced: 0 },
   });
   const [refundTimeout, setRefundTimeout] = useState<NodeJS.Timeout | null>(null);
+  const [processingRefund, setProcessingRefund] = useState<string | null>(null);
 
   // Marketing/Promo states
   const [showPromoForm, setShowPromoForm] = useState(false);
@@ -539,7 +540,7 @@ export function AdminPanel({
     setRefundTimeout(timeout);
   };
 
-  const handleConfirmRefund = (customerId: string, purchaseId: string) => {
+  const handleConfirmRefund = async (customerId: string, purchaseId: string) => {
     // Clear confirmation state and timeout
     setConfirmingRefund(null);
     if (refundTimeout) {
@@ -547,17 +548,42 @@ export function AdminPanel({
       setRefundTimeout(null);
     }
 
-    // Process the refund
-    const updatedCustomers = customers.map(customer => {
-      if (customer.id === customerId) {
-        return {
-          ...customer,
-          purchases: customer.purchases.filter(p => p.id !== purchaseId)
-        };
+    // Set processing state
+    setProcessingRefund(purchaseId);
+
+    try {
+      // Call the refund API endpoint
+      const response = await fetch(`/api/purchases/${purchaseId}/refund`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to process refund');
       }
-      return customer;
-    });
-    onUpdateCustomers(updatedCustomers);
+
+      // Success - update local state to remove the purchase
+      const updatedCustomers = customers.map(customer => {
+        if (customer.id === customerId) {
+          return {
+            ...customer,
+            purchases: customer.purchases.filter(p => p.id !== purchaseId)
+          };
+        }
+        return customer;
+      });
+      onUpdateCustomers(updatedCustomers);
+
+      // Show success message
+      alert(data.message || 'Refund processed successfully!');
+    } catch (error) {
+      console.error('Refund failed:', error);
+      alert(error instanceof Error ? error.message : 'Failed to process refund. Please try again.');
+    } finally {
+      setProcessingRefund(null);
+    }
   };
 
   const renderDashboard = () => (
@@ -797,6 +823,7 @@ export function AdminPanel({
                     <p className="font-semibold">{formatCurrency(purchase.price)}</p>
                     <Button
                       onClick={() => {
+                        if (processingRefund === purchase.id) return; // Prevent double-click
                         if (confirmingRefund === purchase.id && customer) {
                           handleConfirmRefund(customer.id, purchase.id);
                         } else {
@@ -805,13 +832,20 @@ export function AdminPanel({
                       }}
                       size="sm"
                       variant="outline"
+                      disabled={processingRefund === purchase.id}
                       className={`mt-1 transition-colors ${
-                        confirmingRefund === purchase.id
+                        processingRefund === purchase.id
+                          ? 'bg-gray-100 text-gray-500 border-gray-300 cursor-not-allowed'
+                          : confirmingRefund === purchase.id
                           ? 'bg-red-100 text-red-700 border-red-300 hover:bg-red-200 animate-pulse'
                           : 'hover:bg-red-50 hover:text-red-600 hover:border-red-300'
                       }`}
                     >
-                      {confirmingRefund === purchase.id ? '✓ Confirm Refund' : 'Refund'}
+                      {processingRefund === purchase.id
+                        ? 'Processing...'
+                        : confirmingRefund === purchase.id
+                        ? '✓ Confirm Refund'
+                        : 'Refund'}
                     </Button>
                   </div>
                 </div>


### PR DESCRIPTION
Previously, the POS refund button only removed purchases from the local UI state without making any API call to Stripe. Customers saw a successful refund message but never received their money back.

Changes:
- Add new API endpoint POST /api/purchases/[id]/refund that:
  - Fetches the purchase from database
  - Calls Stripe refunds.create() with the payment_intent_id
  - Updates purchase status to 'expired'
  - Handles edge cases (gift card purchases, already refunded, etc.)
- Update AdminPanel handleConfirmRefund to call the new API endpoint
- Add loading state with 'Processing...' button text during refund
- Show success/error messages to staff via alerts

Fixes #138