### PR TITLE
Resolve GitHub issue with multithreading

### DIFF
--- a/src/app/api/purchases/pos/route.ts
+++ b/src/app/api/purchases/pos/route.ts
@@ -16,6 +16,7 @@ import { createAdminClient } from '@/lib/supabase/server';
 import { getStripeClient, getStripeCustomerIdColumn, getStripeMode } from '@/lib/stripe/client';
 import { getOrCreateStripeCustomer } from '@/lib/stripe/payment-methods';
 import { logger } from '@/lib/logger';
+import { validateBirthdateForProduct, hasAgeRestriction } from '@/lib/utils/ageUtils';
 
 type PaymentMethod = 'terminal' | 'saved_card' | 'test' | 'cash';
 
@@ -76,6 +77,29 @@ export async function POST(request: NextRequest) {
 
     if (!customer) {
       return NextResponse.json({ error: 'Customer not found' }, { status: 404 });
+    }
+
+    // Age gate validation for passes with age restrictions
+    if (child_id && hasAgeRestriction(product_name)) {
+      const { data: child } = await adminSupabase
+        .from('children')
+        .select('birthdate, name')
+        .eq('id', child_id)
+        .single();
+
+      if (child?.birthdate) {
+        const validation = validateBirthdateForProduct(child.birthdate, product_name);
+        if (!validation.valid) {
+          logger.warn(
+            { customer_id, child_id, childName: child.name, childAge: validation.childAge, product_name },
+            '❌ Age gate validation failed'
+          );
+          return NextResponse.json(
+            { error: validation.error },
+            { status: 400 }
+          );
+        }
+      }
     }
 
     logger.info({ customer_id, product_name, purchase_type, payment_method }, 'Processing POS purchase');

--- a/src/app/api/stripe/direct-payment/route.ts
+++ b/src/app/api/stripe/direct-payment/route.ts
@@ -18,6 +18,7 @@ import { getOrCreateStripeCustomer } from '@/lib/stripe/payment-methods';
 import { applyGiftCardBalance, getUserGiftCardBalance } from '@/lib/services/gift-cards';
 import { logger } from '@/lib/logger';
 import * as Sentry from '@sentry/nextjs';
+import { validateBirthdateForProduct, hasAgeRestriction } from '@/lib/utils/ageUtils';
 
 export async function POST(request: NextRequest) {
   try {
@@ -96,6 +97,29 @@ export async function POST(request: NextRequest) {
         { error: 'Invalid payment method. Please select a valid saved card.' },
         { status: 400 }
       );
+    }
+
+    // Age gate validation for passes with age restrictions
+    if (childId && hasAgeRestriction(productName)) {
+      const { data: child } = await adminSupabase
+        .from('children')
+        .select('birthdate, name')
+        .eq('id', childId)
+        .single();
+
+      if (child?.birthdate) {
+        const validation = validateBirthdateForProduct(child.birthdate, productName);
+        if (!validation.valid) {
+          logger.warn(
+            { ...logContext, childId, childName: child.name, childAge: validation.childAge },
+            '❌ Age gate validation failed'
+          );
+          return NextResponse.json(
+            { error: validation.error },
+            { status: 400 }
+          );
+        }
+      }
     }
 
     // Calculate amounts

--- a/src/app/api/stripe/kiosk-payment/route.ts
+++ b/src/app/api/stripe/kiosk-payment/route.ts
@@ -21,6 +21,7 @@ import { getStripeClient, getStripeCustomerIdColumn } from "@/lib/stripe/client"
 import { getOrCreateStripeCustomer } from "@/lib/stripe/payment-methods";
 import { logger } from "@/lib/logger";
 import * as Sentry from "@sentry/nextjs";
+import { validateBirthdateForProduct, hasAgeRestriction } from "@/lib/utils/ageUtils";
 
 export async function POST(request: NextRequest) {
     const adminSupabase = createAdminClient();
@@ -107,6 +108,29 @@ export async function POST(request: NextRequest) {
                 { error: "Invalid payment method. Please select a valid saved card." },
                 { status: 400 }
             );
+        }
+
+        // Age gate validation for passes with age restrictions
+        if (childId && hasAgeRestriction(productName)) {
+            const { data: child } = await adminSupabase
+                .from("children")
+                .select("birthdate, name")
+                .eq("id", childId)
+                .single();
+
+            if (child?.birthdate) {
+                const validation = validateBirthdateForProduct(child.birthdate, productName);
+                if (!validation.valid) {
+                    logger.warn(
+                        { ...logContext, childId, childName: child.name, childAge: validation.childAge },
+                        "❌ Age gate validation failed"
+                    );
+                    return NextResponse.json(
+                        { error: validation.error },
+                        { status: 400 }
+                    );
+                }
+            }
         }
 
         // Get or create Stripe customer

--- a/src/components/pos/CheckIn.tsx
+++ b/src/components/pos/CheckIn.tsx
@@ -7,6 +7,7 @@ import { PartySchedulingModal } from "./PartySchedulingModal";
 import { SuccessModal } from "@/components/ui/SuccessModal";
 import { AddPaymentMethodModal } from "./AddPaymentMethodModal";
 import { formatCurrency } from "@/lib/utils/productHelpers";
+import { validateAgeForProduct, hasAgeRestriction, getProductAgeGroup, getAgeGroup } from "@/lib/utils/ageUtils";
 
 interface Child {
     id: string;
@@ -1181,6 +1182,23 @@ export function CheckIn({
                 });
                 setShowSuccessModal(true);
                 return;
+            }
+
+            // Age gate validation - check if child's age matches the pass type
+            if (selectedChild && hasAgeRestriction(product.name)) {
+                const ageValidation = validateAgeForProduct(selectedChild.age, product.name);
+                if (!ageValidation.valid) {
+                    const productAgeGroup = getProductAgeGroup(product.name);
+                    const childAgeGroup = getAgeGroup(selectedChild.age);
+                    const suggestedPassType = childAgeGroup === 'infant' ? 'infant' : 'toddler';
+
+                    setSuccessDetails({
+                        title: "Age Restriction",
+                        message: ageValidation.error || `This pass is not appropriate for ${selectedChild.name}'s age. Please select a ${suggestedPassType} pass instead.`,
+                    });
+                    setShowSuccessModal(true);
+                    return;
+                }
             }
         }
 

--- a/src/lib/utils/ageUtils.ts
+++ b/src/lib/utils/ageUtils.ts
@@ -1,0 +1,159 @@
+/**
+ * Age Utility Functions
+ * Handles age calculation and age-based product validation for passes and punch cards
+ */
+
+// Age group types
+export type AgeGroup = 'infant' | 'toddler';
+
+// Age threshold: children under 2 are infants, 2 and over are toddlers
+const TODDLER_AGE_THRESHOLD = 2;
+
+/**
+ * Calculate age from birthdate
+ * @param birthdate - ISO date string (YYYY-MM-DD)
+ * @returns Age in years
+ */
+export function calculateAge(birthdate: string): number {
+  const today = new Date();
+  const birth = new Date(birthdate);
+  let age = today.getFullYear() - birth.getFullYear();
+  const monthDiff = today.getMonth() - birth.getMonth();
+
+  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
+    age--;
+  }
+
+  return age;
+}
+
+/**
+ * Get the age group for a given age
+ * @param age - Age in years
+ * @returns 'infant' if under 2, 'toddler' if 2 or over
+ */
+export function getAgeGroup(age: number): AgeGroup {
+  return age < TODDLER_AGE_THRESHOLD ? 'infant' : 'toddler';
+}
+
+/**
+ * Get the age group for a child based on birthdate
+ * @param birthdate - ISO date string (YYYY-MM-DD)
+ * @returns 'infant' if under 2, 'toddler' if 2 or over
+ */
+export function getAgeGroupFromBirthdate(birthdate: string): AgeGroup {
+  return getAgeGroup(calculateAge(birthdate));
+}
+
+/**
+ * Extract the required age group from a product name
+ * Looks for "Infant" or "Toddler" in the product name
+ * @param productName - The product name to check
+ * @returns 'infant', 'toddler', or null if no age restriction
+ */
+export function getProductAgeGroup(productName: string): AgeGroup | null {
+  const lowerName = productName.toLowerCase();
+
+  if (lowerName.includes('infant')) {
+    return 'infant';
+  }
+
+  if (lowerName.includes('toddler')) {
+    return 'toddler';
+  }
+
+  return null;
+}
+
+/**
+ * Check if a product has age restrictions
+ * @param productName - The product name to check
+ * @returns true if the product has an age restriction
+ */
+export function hasAgeRestriction(productName: string): boolean {
+  return getProductAgeGroup(productName) !== null;
+}
+
+/**
+ * Validate if a child's age is appropriate for a product
+ * @param childAge - Age of the child in years
+ * @param productName - Name of the product being purchased
+ * @returns Object with valid status and error message if invalid
+ */
+export function validateAgeForProduct(
+  childAge: number,
+  productName: string
+): { valid: boolean; error?: string } {
+  const productAgeGroup = getProductAgeGroup(productName);
+
+  // No age restriction on this product
+  if (productAgeGroup === null) {
+    return { valid: true };
+  }
+
+  const childAgeGroup = getAgeGroup(childAge);
+
+  if (productAgeGroup === childAgeGroup) {
+    return { valid: true };
+  }
+
+  // Age mismatch - provide helpful error message
+  if (productAgeGroup === 'infant' && childAgeGroup === 'toddler') {
+    return {
+      valid: false,
+      error: `This infant pass is only for children under ${TODDLER_AGE_THRESHOLD}. This child is ${childAge} years old. Please select a toddler pass instead.`,
+    };
+  }
+
+  if (productAgeGroup === 'toddler' && childAgeGroup === 'infant') {
+    return {
+      valid: false,
+      error: `This toddler pass is for children ${TODDLER_AGE_THRESHOLD} and over. This child is ${childAge} year${childAge === 1 ? '' : 's'} old. Please select an infant pass instead.`,
+    };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Validate if a child's birthdate allows them to purchase a product
+ * @param childBirthdate - ISO date string (YYYY-MM-DD)
+ * @param productName - Name of the product being purchased
+ * @returns Object with valid status and error message if invalid
+ */
+export function validateBirthdateForProduct(
+  childBirthdate: string,
+  productName: string
+): { valid: boolean; error?: string; childAge?: number } {
+  const childAge = calculateAge(childBirthdate);
+  const validation = validateAgeForProduct(childAge, productName);
+
+  return {
+    ...validation,
+    childAge,
+  };
+}
+
+/**
+ * Get a human-readable label for an age group
+ * @param ageGroup - The age group
+ * @returns Human-readable label
+ */
+export function getAgeGroupLabel(ageGroup: AgeGroup): string {
+  return ageGroup === 'infant' ? 'Under 2 years' : '2 years and over';
+}
+
+/**
+ * Get the age range description for a product
+ * @param productName - Name of the product
+ * @returns Human-readable age range or null if no restriction
+ */
+export function getProductAgeRange(productName: string): string | null {
+  const ageGroup = getProductAgeGroup(productName);
+
+  if (ageGroup === null) {
+    return null;
+  }
+
+  return getAgeGroupLabel(ageGroup);
+}


### PR DESCRIPTION
Implements age-based purchase restrictions for infant and toddler products:
- Infant passes/punch cards: only purchasable for children under 2 years old
- Toddler passes/punch cards: only purchasable for children 2 years and over

Changes:
- Create shared age utilities in src/lib/utils/ageUtils.ts
  - calculateAge: calculates age from birthdate
  - getAgeGroup: determines if child is infant or toddler
  - getProductAgeGroup: extracts age group from product name
  - validateAgeForProduct: validates if child's age matches product requirements
- Add age validation to all purchase API routes:
  - /api/purchases/pos - staff POS purchases
  - /api/stripe/kiosk-payment - self-serve kiosk purchases
  - /api/stripe/direct-payment - web direct purchases
- Add frontend validation in CheckIn.tsx with user-friendly error messages

Closes #135