### PR TITLE
🐛 Fix contact form submission error

### DIFF
--- a/src/lib/services/contact.ts
+++ b/src/lib/services/contact.ts
@@ -4,12 +4,33 @@
  */
 
 import { createAdminClient, createClient } from '@/lib/supabase/server';
+import { createClient as createBrowserClient } from '@supabase/supabase-js';
 import { logger } from '@/lib/logger';
 import { Database } from '@/lib/supabase/database.types';
 
 // Database types
 type ContactSubmission = Database['public']['Tables']['contact_submissions']['Row'];
 type ContactSubmissionInsert = Database['public']['Tables']['contact_submissions']['Insert'];
+
+/**
+ * Create a basic Supabase client for anonymous operations
+ * Uses the anon key which works with RLS policies for public inserts
+ */
+function createAnonClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !anonKey) {
+    return null;
+  }
+
+  return createBrowserClient<Database>(url, anonKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}
 
 export interface ContactSubmissionData {
   id: string;
@@ -59,34 +80,69 @@ function toContactData(row: ContactSubmission): ContactSubmissionData {
 /**
  * Save a contact form submission to the database
  * This is the primary storage - email sending is secondary
+ *
+ * Uses a two-tier approach:
+ * 1. First tries the admin client (service role key) which bypasses RLS
+ * 2. Falls back to anon client if service role key isn't configured
  */
 export async function saveContactSubmission(options: SaveContactOptions): Promise<SaveContactResult> {
   const { name, email, phone, userType, message } = options;
   const normalizedEmail = email.toLowerCase().trim();
 
+  const insertData: ContactSubmissionInsert = {
+    name: name.trim(),
+    email: normalizedEmail,
+    phone: phone?.trim() || null,
+    user_type: userType,
+    message: message.trim(),
+    email_sent: false,
+  };
+
   try {
-    // Check if SUPABASE_SERVICE_ROLE_KEY is configured
-    if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
-      logger.error(
-        { email: normalizedEmail },
-        'SUPABASE_SERVICE_ROLE_KEY not configured - cannot save contact submission'
+    // Try admin client first (bypasses RLS, preferred method)
+    if (process.env.SUPABASE_SERVICE_ROLE_KEY) {
+      const adminResult = await saveWithAdminClient(insertData, normalizedEmail);
+      if (adminResult.success) {
+        return adminResult;
+      }
+      // If admin client failed, log and try fallback
+      logger.warn(
+        { error: adminResult.error, email: normalizedEmail },
+        'Admin client failed, attempting fallback to anon client'
       );
-      return {
-        success: false,
-        error: 'Database configuration error',
-      };
+    } else {
+      logger.info(
+        { email: normalizedEmail },
+        'SUPABASE_SERVICE_ROLE_KEY not configured, using anon client'
+      );
     }
 
-    const supabase = createAdminClient();
+    // Fallback: Try anon client (uses RLS policy "Anyone can submit contact form")
+    const anonResult = await saveWithAnonClient(insertData, normalizedEmail);
+    return anonResult;
 
-    const insertData: ContactSubmissionInsert = {
-      name: name.trim(),
-      email: normalizedEmail,
-      phone: phone?.trim() || null,
-      user_type: userType,
-      message: message.trim(),
-      email_sent: false,
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    logger.error(
+      { error, errorMessage, email: normalizedEmail },
+      'Contact submission save exception'
+    );
+    return {
+      success: false,
+      error: `Exception: ${errorMessage}`,
     };
+  }
+}
+
+/**
+ * Save contact submission using the admin client (service role key)
+ */
+async function saveWithAdminClient(
+  insertData: ContactSubmissionInsert,
+  normalizedEmail: string
+): Promise<SaveContactResult> {
+  try {
+    const supabase = createAdminClient();
 
     const { data, error } = await supabase
       .from('contact_submissions')
@@ -95,7 +151,6 @@ export async function saveContactSubmission(options: SaveContactOptions): Promis
       .single();
 
     if (error) {
-      // Log detailed error info to help debug
       logger.error(
         {
           error,
@@ -103,14 +158,13 @@ export async function saveContactSubmission(options: SaveContactOptions): Promis
           errorMessage: error.message,
           errorDetails: error.details,
           errorHint: error.hint,
-          email: normalizedEmail
+          email: normalizedEmail,
+          clientType: 'admin'
         },
-        'Failed to save contact submission to database'
+        'Failed to save contact submission with admin client'
       );
 
-      // Provide more specific error messages based on the error type
       if (error.code === '42P01') {
-        // Table doesn't exist
         return {
           success: false,
           error: 'Database table not found - migration may need to be applied',
@@ -124,8 +178,8 @@ export async function saveContactSubmission(options: SaveContactOptions): Promis
     }
 
     logger.info(
-      { submissionId: data.id, email: normalizedEmail, userType },
-      '📝 Contact form submission saved'
+      { submissionId: data.id, email: normalizedEmail, clientType: 'admin' },
+      '📝 Contact form submission saved (admin client)'
     );
 
     return {
@@ -134,13 +188,88 @@ export async function saveContactSubmission(options: SaveContactOptions): Promis
     };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return {
+      success: false,
+      error: `Admin client exception: ${errorMessage}`,
+    };
+  }
+}
+
+/**
+ * Save contact submission using the anon client (relies on RLS policy)
+ */
+async function saveWithAnonClient(
+  insertData: ContactSubmissionInsert,
+  normalizedEmail: string
+): Promise<SaveContactResult> {
+  const supabase = createAnonClient();
+
+  if (!supabase) {
     logger.error(
-      { error, errorMessage, email: normalizedEmail },
-      'Contact submission save exception'
+      { email: normalizedEmail },
+      'Neither admin nor anon Supabase client could be created - check environment variables'
     );
     return {
       success: false,
-      error: `Exception: ${errorMessage}`,
+      error: 'Database configuration error - missing Supabase credentials',
+    };
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('contact_submissions')
+      .insert(insertData)
+      .select('id')
+      .single();
+
+    if (error) {
+      logger.error(
+        {
+          error,
+          errorCode: error.code,
+          errorMessage: error.message,
+          errorDetails: error.details,
+          errorHint: error.hint,
+          email: normalizedEmail,
+          clientType: 'anon'
+        },
+        'Failed to save contact submission with anon client'
+      );
+
+      if (error.code === '42P01') {
+        return {
+          success: false,
+          error: 'Database table not found - migration may need to be applied',
+        };
+      }
+
+      if (error.code === '42501') {
+        return {
+          success: false,
+          error: 'Permission denied - RLS policy may need to be updated. Please run migration 015.',
+        };
+      }
+
+      return {
+        success: false,
+        error: `Database error: ${error.message}`,
+      };
+    }
+
+    logger.info(
+      { submissionId: data.id, email: normalizedEmail, clientType: 'anon' },
+      '📝 Contact form submission saved (anon client)'
+    );
+
+    return {
+      success: true,
+      submissionId: data.id,
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return {
+      success: false,
+      error: `Anon client exception: ${errorMessage}`,
     };
   }
 }

--- a/supabase/migrations/015_fix_contact_rls_policy.sql
+++ b/supabase/migrations/015_fix_contact_rls_policy.sql
@@ -1,0 +1,26 @@
+-- ==================== FIX CONTACT SUBMISSIONS RLS POLICY ====================
+--
+-- The original policy used "TO public" which refers to the PostgreSQL public role.
+-- In Supabase, anonymous users connect with the "anon" role, not "public".
+-- This migration updates the policy to explicitly allow anon and authenticated users.
+--
+
+-- Drop the existing policy
+DROP POLICY IF EXISTS "Anyone can submit contact form" ON public.contact_submissions;
+
+-- Create new policy that explicitly allows anon and authenticated users to insert
+-- This ensures the contact form works for all website visitors
+CREATE POLICY "Anyone can submit contact form"
+  ON public.contact_submissions
+  FOR INSERT
+  TO anon, authenticated
+  WITH CHECK (true);
+
+-- Also fix newsletter_subscribers for consistency
+DROP POLICY IF EXISTS "Anyone can subscribe to newsletter" ON public.newsletter_subscribers;
+
+CREATE POLICY "Anyone can subscribe to newsletter"
+  ON public.newsletter_subscribers
+  FOR INSERT
+  TO anon, authenticated
+  WITH CHECK (true);


### PR DESCRIPTION
## Summary

Fixes #78 - Contact form failing to submit

### Root Cause

The issue had two contributing factors:

1. **RLS Policy Issue**: The RLS policy used `TO public` which refers to the PostgreSQL public role, but Supabase uses `anon` and `authenticated` roles for API access

2. **No Fallback Mechanism**: The contact service would fail completely if `SUPABASE_SERVICE_ROLE_KEY` wasn't configured

### Changes

**Migration 015 - Fix RLS Policy**
- Updates the `contact_submissions` INSERT policy to use `TO anon, authenticated` explicitly
- Also fixes `newsletter_subscribers` for consistency

**Contact Service Enhancement**
- Adds a two-tier approach for saving submissions:
  1. First tries admin client (service role key) which bypasses RLS
  2. Falls back to anon client if service role key isn't available
- Better error handling and logging for both paths
- Specific error messages for common failures (table not found, permission denied)

## Test Plan

- [ ] Run migration 015 against production database
- [ ] Test contact form submission in production
- [ ] Verify submissions are being saved to `contact_submissions` table
- [ ] Check Sentry/logs for any new errors

## Deployment Notes

⚠️ **Important**: Run migration `015_fix_contact_rls_policy.sql` on the production database:
```sql
-- Run in Supabase SQL Editor
DROP POLICY IF EXISTS "Anyone can submit contact form" ON public.contact_submissions;
CREATE POLICY "Anyone can submit contact form"
  ON public.contact_submissions
  FOR INSERT
  TO anon, authenticated
  WITH CHECK (true);

DROP POLICY IF EXISTS "Anyone can subscribe to newsletter" ON public.newsletter_subscribers;
CREATE POLICY "Anyone can subscribe to newsletter"
  ON public.newsletter_subscribers
  FOR INSERT
  TO anon, authenticated
  WITH CHECK (true);
```