### PR TITLE
🐛 Fix booking calendar timezone bug causing dates to show one day off

### DIFF
--- a/src/app/admin/parties/page.tsx
+++ b/src/app/admin/parties/page.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/components/ui/Button';
 import { logger } from '@/lib/client-logger';
 import { Database } from '@/lib/supabase/database.types';
 import { PACKAGE_PRICING } from '@/lib/validations/party-booking';
+import { parseDateString } from '@/lib/utils';
 
 type PartyBooking = Database['public']['Tables']['party_bookings']['Row'];
 
@@ -158,7 +159,7 @@ export default function AdminPartiesPage() {
   };
 
   const formatDate = (dateStr: string) => {
-    const date = new Date(dateStr + 'T00:00:00');
+    const date = parseDateString(dateStr);
     return date.toLocaleDateString('en-US', { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' });
   };
 

--- a/src/app/api/party-booking/create/route.ts
+++ b/src/app/api/party-booking/create/route.ts
@@ -10,6 +10,7 @@ import { CompleteBookingSchema, calculateBookingPrice, PACKAGE_PRICING } from '@
 import { createCheckoutSession } from '@/lib/stripe/checkout';
 import { createClient } from '@/lib/supabase/server';
 import { logger } from '@/lib/logger';
+import { parseDateString } from '@/lib/utils';
 
 export async function POST(request: NextRequest) {
   let bookingId: string | undefined;
@@ -117,7 +118,7 @@ export async function POST(request: NextRequest) {
       return `${displayHour}:${minutes} ${ampm}`;
     };
 
-    const partyDate = new Date(bookingData.partyDate + 'T00:00:00');
+    const partyDate = parseDateString(bookingData.partyDate);
     const formattedDate = partyDate.toLocaleDateString('en-US', {
       weekday: 'long',
       month: 'long',

--- a/src/app/parties/success/page.tsx
+++ b/src/app/parties/success/page.tsx
@@ -8,6 +8,7 @@ import { Layout } from '@/components/layout/Layout';
 import { Button } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
 import Link from 'next/link';
+import { parseDateString } from '@/lib/utils';
 
 interface BookingDetails {
   id: string;
@@ -71,7 +72,7 @@ function SuccessContent() {
   };
 
   const formatDate = (dateString: string) => {
-    return new Date(dateString + 'T00:00:00').toLocaleDateString('en-US', {
+    return parseDateString(dateString).toLocaleDateString('en-US', {
       weekday: 'long',
       year: 'numeric',
       month: 'long',

--- a/src/components/parties/PartyCalendar.tsx
+++ b/src/components/parties/PartyCalendar.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
 import { ChevronLeft, ChevronRight, Calendar, Clock, Users, MapPin } from 'lucide-react';
-import { formatDateToYYYYMMDD } from '@/lib/utils';
+import { formatDateToYYYYMMDD, parseDateString } from '@/lib/utils';
 
 export interface PartyBooking {
   id: string;
@@ -372,7 +372,7 @@ export function PartyCalendar({
               
               {selectedDate ? (
                 <div className="space-y-3">
-                  {getAvailableTimeSlots(new Date(selectedDate + 'T00:00:00')).map((slot, index) => (
+                  {getAvailableTimeSlots(parseDateString(selectedDate)).map((slot, index) => (
                     <button
                       key={index}
                       onClick={() => handleTimeSlotClick(selectedDate, slot)}

--- a/src/components/parties/booking-steps/DateTimeStep.tsx
+++ b/src/components/parties/booking-steps/DateTimeStep.tsx
@@ -10,7 +10,7 @@ import {
   isValidBookingDate,
   hasAvailableSlots,
 } from '@/lib/validations/party-booking';
-import { formatDateToYYYYMMDD } from '@/lib/utils';
+import { formatDateToYYYYMMDD, parseDateString } from '@/lib/utils';
 import type { BookingFormData } from '../PartyBookingWizard';
 
 interface DateTimeStepProps {
@@ -118,8 +118,9 @@ export function DateTimeStep({ formData, onUpdate, onValidChange }: DateTimeStep
   minBookingDate.setDate(minBookingDate.getDate() + 7);
 
   // Get available time slots for selected date
+  // Use parseDateString to avoid UTC vs local timezone bug
   const selectedDateObj = formData.partyDate
-    ? new Date(formData.partyDate + 'T00:00:00')
+    ? parseDateString(formData.partyDate)
     : null;
   const availableSlots =
     selectedDateObj && formData.partyType
@@ -223,7 +224,7 @@ export function DateTimeStep({ formData, onUpdate, onValidChange }: DateTimeStep
           <h4 className="text-lg font-semibold mb-4 flex items-center">
             <Clock className="w-5 h-5 mr-2 text-honey-600" />
             {formData.partyDate
-              ? new Date(formData.partyDate + 'T00:00:00').toLocaleDateString('en-US', {
+              ? parseDateString(formData.partyDate).toLocaleDateString('en-US', {
                   weekday: 'long',
                   month: 'long',
                   day: 'numeric',

--- a/src/components/parties/booking-steps/ReviewStep.tsx
+++ b/src/components/parties/booking-steps/ReviewStep.tsx
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react';
 import { Card } from '@/components/ui/Card';
 import { PACKAGE_PRICING } from '@/lib/validations/party-booking';
+import { parseDateString } from '@/lib/utils';
 import type { BookingFormData } from '../PartyBookingWizard';
 
 interface ReviewStepProps {
@@ -44,7 +45,7 @@ export function ReviewStep({ formData, pricing, onValidChange }: ReviewStepProps
   };
 
   const formatDate = (dateString: string) => {
-    return new Date(dateString + 'T00:00:00').toLocaleDateString('en-US', {
+    return parseDateString(dateString).toLocaleDateString('en-US', {
       weekday: 'long',
       year: 'numeric',
       month: 'long',

--- a/src/lib/services/party-bookings.ts
+++ b/src/lib/services/party-bookings.ts
@@ -12,7 +12,7 @@ import {
   getAvailableTimeSlots,
   isValidBookingDate,
 } from '../validations/party-booking';
-import { formatDateToYYYYMMDD } from '../utils';
+import { formatDateToYYYYMMDD, parseDateString } from '../utils';
 
 type PartyBooking = Database['public']['Tables']['party_bookings']['Row'];
 type PartyBookingInsert = Database['public']['Tables']['party_bookings']['Insert'];
@@ -143,7 +143,8 @@ export async function getDateAvailability(
   date: string,
   partyType: 'private' | 'semi_private'
 ): Promise<TimeSlotAvailability[]> {
-  const dateObj = new Date(date + 'T00:00:00');
+  // Use parseDateString to avoid UTC vs local timezone bug
+  const dateObj = parseDateString(date);
 
   // Get possible time slots for this date and party type
   const possibleSlots = getAvailableTimeSlots(dateObj, partyType);
@@ -267,7 +268,8 @@ export async function createPartyBooking(
   }
 
   // Validate booking date (at least 1 week in advance)
-  const partyDate = new Date(bookingData.partyDate + 'T00:00:00');
+  // Use parseDateString to avoid UTC vs local timezone bug
+  const partyDate = parseDateString(bookingData.partyDate);
   if (!isValidBookingDate(partyDate)) {
     throw new Error('Parties must be booked at least 1 week in advance');
   }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -71,6 +71,18 @@ export function formatDateToYYYYMMDD(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
+/**
+ * Parses a YYYY-MM-DD date string to a Date object in LOCAL timezone.
+ * This avoids the timezone bug where new Date("2025-01-18") parses as UTC midnight,
+ * which for users west of UTC shifts the date back by one day.
+ *
+ * ALWAYS use this function instead of new Date(dateString) for date-only strings.
+ */
+export function parseDateString(dateString: string): Date {
+  const [year, month, day] = dateString.split('-').map(Number);
+  return new Date(year, month - 1, day);
+}
+
 // Business hours helpers
 export function isOpen(): boolean {
   const now = new Date()

--- a/src/lib/validations/party-booking.ts
+++ b/src/lib/validations/party-booking.ts
@@ -4,6 +4,7 @@
  */
 
 import { z } from 'zod';
+import { parseDateString } from '@/lib/utils';
 
 // Phone number regex for (XXX) XXX-XXXX format
 const phoneRegex = /^\(\d{3}\) \d{3}-\d{4}$/;
@@ -54,7 +55,10 @@ export const DateTimeSelectionSchema = z.object({
   partyDate: z
     .string()
     .refine((date) => {
-      const selectedDate = new Date(date);
+      // Use parseDateString to avoid UTC vs local timezone bug
+      // new Date("2025-01-18") parses as UTC midnight, which shifts
+      // the date back one day for users west of UTC
+      const selectedDate = parseDateString(date);
       const today = new Date();
       today.setHours(0, 0, 0, 0);
       const minBookingDate = new Date(today);


### PR DESCRIPTION
The booking calendar was displaying incorrect dates and time slots due to
a timezone parsing bug. When JavaScript parses a date string like "2025-01-18"
(without time), it interprets it as UTC midnight, which shifts the date
back one day for users west of UTC (Americas).

Changes:
- Add parseDateString() utility function that safely parses YYYY-MM-DD
  strings in local timezone using new Date(year, month, day)
- Replace all instances of new Date(dateString + 'T00:00:00') with
  parseDateString(dateString) for consistent date handling
- Fix DateTimeSelectionSchema validation that was comparing UTC dates
  against local dates for the 7-day advance booking check

Files updated:
- src/lib/utils.ts - Added parseDateString() function
- src/lib/validations/party-booking.ts - Fixed date validation
- src/components/parties/booking-steps/DateTimeStep.tsx
- src/lib/services/party-bookings.ts
- src/components/parties/PartyCalendar.tsx
- src/app/parties/success/page.tsx
- src/components/parties/booking-steps/ReviewStep.tsx
- src/app/admin/parties/page.tsx
- src/app/api/party-booking/create/route.ts