### PR TITLE
Fix missing confirm button in delete user dialog

### DIFF
--- a/src/components/pos/AdminPanel.tsx
+++ b/src/components/pos/AdminPanel.tsx
@@ -1123,8 +1123,7 @@ export function AdminPanel({
                         <Button
                           onClick={() => handleDeleteCustomer(customer.id)}
                           size="sm"
-                          variant="outline"
-                          className="bg-red-500 text-white hover:bg-red-600 border-red-500"
+                          className="bg-red-500 text-white hover:bg-red-600 border-2 border-red-500 rounded-2xl"
                           disabled={deletingCustomerId === customer.id}
                         >
                           {deletingCustomerId === customer.id ? 'Deleting...' : 'Yes, Delete'}


### PR DESCRIPTION
The "Yes, Delete" button text was invisible due to a CSS conflict. The Button's `variant="outline"` was applying `text-charcoal-700` which overrode the `text-white` in the className.

Removed the variant and added necessary styles directly to className to ensure the red confirm button displays properly.