### PR TITLE
Fix party booking date off by one day

### DIFF
--- a/src/app/admin/parties/page.tsx
+++ b/src/app/admin/parties/page.tsx
@@ -11,7 +11,7 @@ import { Button } from '@/components/ui/Button';
 import { logger } from '@/lib/client-logger';
 import { Database } from '@/lib/supabase/database.types';
 import { PACKAGE_PRICING } from '@/lib/validations/party-booking';
-import { parseDateString } from '@/lib/utils';
+import { parseDateString, formatDateToYYYYMMDD } from '@/lib/utils';
 
 type PartyBooking = Database['public']['Tables']['party_bookings']['Row'];
 
@@ -113,7 +113,7 @@ export default function AdminPartiesPage() {
     }
 
     // Date filter
-    const today = new Date().toISOString().split('T')[0];
+    const today = formatDateToYYYYMMDD(new Date());
     if (dateFilter === 'upcoming') {
       filtered = filtered.filter((b) => b.party_date >= today);
     } else if (dateFilter === 'past') {
@@ -180,7 +180,7 @@ export default function AdminPartiesPage() {
     total: bookings.length,
     pending: bookings.filter((b) => b.status === 'pending').length,
     confirmed: bookings.filter((b) => b.status === 'confirmed').length,
-    upcoming: bookings.filter((b) => b.party_date >= new Date().toISOString().split('T')[0]).length,
+    upcoming: bookings.filter((b) => b.party_date >= formatDateToYYYYMMDD(new Date())).length,
     totalRevenue: bookings
       .filter((b) => b.status !== 'cancelled')
       .reduce((sum, b) => sum + b.total_price, 0),

--- a/src/components/parties/PartyBookingForm.tsx
+++ b/src/components/parties/PartyBookingForm.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Button } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
 import { X, Calendar, Clock, Users, DollarSign } from 'lucide-react';
+import { parseDateString } from '@/lib/utils';
 import type { PartyBooking } from './PartyCalendar';
 
 interface TimeSlot {
@@ -41,7 +42,7 @@ export function PartyBookingForm({ selectedDate, selectedTimeSlot, onClose, onSu
   };
 
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
+    return parseDateString(dateString).toLocaleDateString('en-US', {
       weekday: 'long',
       year: 'numeric',
       month: 'long',

--- a/src/components/parties/PartyCalendar.tsx
+++ b/src/components/parties/PartyCalendar.tsx
@@ -138,7 +138,7 @@ export function PartyCalendar({
   };
 
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
+    return parseDateString(dateString).toLocaleDateString('en-US', {
       weekday: 'long',
       year: 'numeric',
       month: 'long',

--- a/src/lib/services/promos.ts
+++ b/src/lib/services/promos.ts
@@ -5,6 +5,7 @@
 
 import { createClient } from '../supabase/server';
 import { Database } from '../supabase/database.types';
+import { formatDateToYYYYMMDD } from '../utils';
 
 type Promo = Database['public']['Tables']['promos']['Row'];
 type PromoInsert = Database['public']['Tables']['promos']['Insert'];
@@ -35,7 +36,7 @@ export async function getPromo(id: string): Promise<Promo | null> {
  */
 export async function getActivePromos(): Promise<Promo[]> {
   const supabase = await createClient();
-  const today = new Date().toISOString().split('T')[0];
+  const today = formatDateToYYYYMMDD(new Date());
 
   const { data, error } = await supabase
     .from('promos')

--- a/src/lib/services/purchases.ts
+++ b/src/lib/services/purchases.ts
@@ -5,6 +5,7 @@
 
 import { createClient, createAdminClient } from "../supabase/server";
 import { Database } from "../supabase/database.types";
+import { formatDateToYYYYMMDD } from "../utils";
 
 type Purchase = Database["public"]["Tables"]["purchases"]["Row"];
 type PurchaseInsert = Database["public"]["Tables"]["purchases"]["Insert"];
@@ -153,7 +154,7 @@ export async function deletePurchase(id: string): Promise<void> {
  */
 export async function getTodayPurchases(): Promise<Purchase[]> {
     const supabase = await createClient();
-    const today = new Date().toISOString().split("T")[0];
+    const today = formatDateToYYYYMMDD(new Date());
 
     const { data, error } = await supabase
         .from("purchases")


### PR DESCRIPTION
Replace incorrect date parsing patterns that caused dates to display 1 day ahead due to UTC/local timezone mismatch.

- PartyBookingForm.tsx: Use parseDateString() for date display
- PartyCalendar.tsx: Use parseDateString() for date display
- admin/parties/page.tsx: Use formatDateToYYYYMMDD() for today comparison
- promos.ts: Use formatDateToYYYYMMDD() for active promo filtering
- purchases.ts: Use formatDateToYYYYMMDD() for today's purchases query

Root cause: new Date("YYYY-MM-DD") parses as UTC midnight, which shifts to the previous day in western timezones. The utility functions parseDateString() and formatDateToYYYYMMDD() handle dates in local time.