### PR TITLE
✨ Rename party status 'completed' → 'done' for clarity

### DIFF
--- a/src/app/admin/parties/README.md
+++ b/src/app/admin/parties/README.md
@@ -11,14 +11,14 @@ Comprehensive admin interface for managing party bookings and packages.
 ### 1. Party Bookings Management
 - **View all bookings** with comprehensive details
 - **Filter by**:
-  - Status (pending, confirmed, cancelled, completed)
+  - Status (pending, confirmed, cancelled, done)
   - Party type (private, semi-private)
   - Date range (upcoming, past, custom)
   - Search (customer name, email, phone, child name)
 - **Quick actions**:
   - Confirm pending bookings
   - Cancel bookings
-  - Mark as completed
+  - Mark as done (party has occurred)
 - **Display information**:
   - Date and time
   - Customer contact info
@@ -64,7 +64,7 @@ Update a party booking's status or details.
 **Body:**
 ```json
 {
-  "status": "confirmed" | "pending" | "cancelled" | "completed",
+  "status": "confirmed" | "pending" | "cancelled" | "done",
   "notes": "Optional notes",
   "party_date": "YYYY-MM-DD",
   "start_time": "HH:MM",

--- a/src/app/admin/parties/page.tsx
+++ b/src/app/admin/parties/page.tsx
@@ -17,7 +17,7 @@ type PartyBooking = Database['public']['Tables']['party_bookings']['Row'];
 type PartyPackage = Database['public']['Tables']['party_packages']['Row'];
 type PartyTimeSlot = Database['public']['Tables']['party_time_slots']['Row'];
 
-type BookingStatus = 'all' | 'pending' | 'confirmed' | 'cancelled' | 'completed';
+type BookingStatus = 'all' | 'pending' | 'confirmed' | 'cancelled' | 'done';
 type PartyType = 'all' | 'private' | 'semi_private';
 type SlotPartyType = 'private' | 'semi_private';
 type DayType = 'weekday' | 'weekend';
@@ -26,7 +26,7 @@ const STATUS_COLORS = {
   pending: 'bg-yellow-100 text-yellow-800 border-yellow-300',
   confirmed: 'bg-green-100 text-green-800 border-green-300',
   cancelled: 'bg-red-100 text-red-800 border-red-300',
-  completed: 'bg-blue-100 text-blue-800 border-blue-300',
+  done: 'bg-blue-100 text-blue-800 border-blue-300',
 };
 
 const PARTY_TYPE_LABELS = {
@@ -410,7 +410,7 @@ export default function AdminPartiesPage() {
         return 'bg-yellow-500';
       case 'cancelled':
         return 'bg-red-500';
-      case 'completed':
+      case 'done':
         return 'bg-blue-500';
       default:
         return 'bg-neutral-400';
@@ -754,7 +754,7 @@ export default function AdminPartiesPage() {
                       <option value="pending">Pending</option>
                       <option value="confirmed">Confirmed</option>
                       <option value="cancelled">Cancelled</option>
-                      <option value="completed">Completed</option>
+                      <option value="done">Done</option>
                     </select>
                   </div>
 
@@ -922,10 +922,10 @@ export default function AdminPartiesPage() {
                           )}
                           {booking.status === 'confirmed' && (
                             <button
-                              onClick={() => updateBookingStatus(booking.id, 'completed')}
+                              onClick={() => updateBookingStatus(booking.id, 'done')}
                               className="text-xs px-2 py-1 bg-blue-500 text-white rounded hover:bg-blue-600"
                             >
-                              Complete
+                              Mark Done
                             </button>
                           )}
                         </div>
@@ -1046,7 +1046,7 @@ export default function AdminPartiesPage() {
                       </div>
                       <div className="flex items-center gap-1.5">
                         <span className="w-2 h-2 rounded-full bg-blue-500" />
-                        <span>Completed</span>
+                        <span>Done</span>
                       </div>
                       <div className="flex items-center gap-1.5">
                         <span className="w-2 h-2 rounded-full bg-red-500" />
@@ -1166,10 +1166,10 @@ export default function AdminPartiesPage() {
                               {booking.status === 'confirmed' && (
                                 <div className="mt-2 pt-2 border-t border-neutral-200">
                                   <button
-                                    onClick={() => updateBookingStatus(booking.id, 'completed')}
+                                    onClick={() => updateBookingStatus(booking.id, 'done')}
                                     className="w-full text-xs px-2 py-1 bg-blue-500 text-white rounded hover:bg-blue-600"
                                   >
-                                    Mark Complete
+                                    Mark Done
                                   </button>
                                 </div>
                               )}

--- a/src/app/api/admin/party-bookings/[id]/route.ts
+++ b/src/app/api/admin/party-bookings/[id]/route.ts
@@ -10,7 +10,7 @@ import { logger } from '@/lib/logger';
 import { z } from 'zod';
 
 const UpdateBookingSchema = z.object({
-  status: z.enum(['pending', 'confirmed', 'cancelled', 'completed']).optional(),
+  status: z.enum(['pending', 'confirmed', 'cancelled', 'done']).optional(),
   notes: z.string().optional(),
   party_date: z.string().optional(),
   start_time: z.string().optional(),

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -559,7 +559,7 @@ export interface Database {
           base_price: number;
           additional_kids_price: number;
           total_price: number;
-          status: 'pending' | 'confirmed' | 'cancelled' | 'completed';
+          status: 'pending' | 'confirmed' | 'cancelled' | 'done';
           notes: string | null;
           stripe_payment_intent_id: string | null;
           stripe_checkout_session_id: string | null;
@@ -587,7 +587,7 @@ export interface Database {
           base_price: number;
           additional_kids_price?: number;
           total_price: number;
-          status?: 'pending' | 'confirmed' | 'cancelled' | 'completed';
+          status?: 'pending' | 'confirmed' | 'cancelled' | 'done';
           notes?: string | null;
           stripe_payment_intent_id?: string | null;
           stripe_checkout_session_id?: string | null;
@@ -615,7 +615,7 @@ export interface Database {
           base_price?: number;
           additional_kids_price?: number;
           total_price?: number;
-          status?: 'pending' | 'confirmed' | 'cancelled' | 'completed';
+          status?: 'pending' | 'confirmed' | 'cancelled' | 'done';
           notes?: string | null;
           stripe_payment_intent_id?: string | null;
           stripe_checkout_session_id?: string | null;

--- a/supabase/migrations/023_rename_completed_to_done.sql
+++ b/supabase/migrations/023_rename_completed_to_done.sql
@@ -1,0 +1,10 @@
+-- ==================== RENAME PARTY STATUS: completed → done ====================
+-- This migration clarifies the party booking status terminology:
+-- - "completed" was confusing (sounds like "booking completed" vs "party occurred")
+-- - "done" clearly indicates the party event has already happened
+
+-- Rename the enum value from 'completed' to 'done'
+ALTER TYPE booking_status RENAME VALUE 'completed' TO 'done';
+
+-- Note: This automatically updates all existing rows that have status='completed'
+-- to status='done' since they reference the enum type.


### PR DESCRIPTION
The term "completed" was confusing because it could mean:
- "completed booking online" (finished payment) → should be 'confirmed'
- "party event has occurred" (past tense) → the actual intent

Renamed to "done" which clearly indicates the party has happened.

Changes:
- Add migration 023 to rename enum value
- Update TypeScript types
- Update admin UI (buttons say "Mark Done" instead of "Complete")
- Update calendar legend and status filters