### PR TITLE
🐛 Fix mobile icon cutoff across all icon card components

### DIFF
--- a/src/components/about/RulesAndWaiver.tsx
+++ b/src/components/about/RulesAndWaiver.tsx
@@ -16,7 +16,7 @@ function RuleSectionIcon({ src, alt, title }: { src: string; alt: string; title:
       src={src}
       alt={alt}
       fill
-      className="object-cover w-full h-full"
+      className="object-contain w-full h-full"
       sizes="(max-width: 768px) 100vw, 33vw"
       onError={() => setFailed(true)}
     />
@@ -129,7 +129,7 @@ export function RulesAndWaiver() {
               <motion.div key={index} variants={fadeInUp}>
                 <Card padding="none" className="h-full border-2 border-primary-200/50 shadow-soft hover:shadow-honey transition-all duration-300 rounded-3xl overflow-hidden">
                   <CardContent className="p-0 flex flex-col">
-                    <div className="w-full h-40 sm:h-48 bg-white relative overflow-hidden">
+                    <div className="w-full h-40 sm:h-48 bg-white relative overflow-hidden p-3 sm:p-4">
                       <RuleSectionIcon src={section.iconSrc} alt={section.title} title={section.title} />
                     </div>
                     <div className="p-6">

--- a/src/components/about/ValuesSection.tsx
+++ b/src/components/about/ValuesSection.tsx
@@ -22,7 +22,7 @@ function ValueIcon({ src, alt, title, className }: { src: string; alt: string; t
       alt={alt}
       width={200}
       height={200}
-      className={`object-cover w-full h-full ${className ?? ''}`}
+      className={`object-contain w-full h-full ${className ?? ''}`}
       onError={() => setFailed(true)}
     />
   )
@@ -72,7 +72,7 @@ export function ValuesSection() {
             <motion.div key={index} variants={fadeInUp}>
               <Card padding="none" className={`h-full text-left group relative overflow-hidden ${value.accentColor} border-2 ${value.accentBorder} shadow-soft hover:shadow-honey transition-all duration-300 hover:-translate-y-1 rounded-3xl`}>
                 <CardContent className="p-0 flex flex-col">
-                  <div className="w-full h-48 sm:h-56 bg-white overflow-hidden relative">
+                  <div className="w-full h-48 sm:h-56 bg-white overflow-hidden relative p-3 sm:p-4">
                     <div className="absolute inset-0">
                       <ValueIcon src={value.iconSrc} alt={value.title} title={value.title} className="w-full h-full" />
                     </div>

--- a/src/components/home/Features.tsx
+++ b/src/components/home/Features.tsx
@@ -22,7 +22,7 @@ function FeatureIcon({ src, alt, title, className }: { src: string; alt: string;
       alt={alt}
       width={200}
       height={200}
-      className={`object-cover w-full h-full ${className ?? ''}`}
+      className={`object-contain w-full h-full ${className ?? ''}`}
       onError={() => setFailed(true)}
     />
   )
@@ -119,7 +119,7 @@ export function Features() {
                 <Card padding="none" className={`h-full text-left group relative overflow-hidden ${feature.accentColor} border-2 ${feature.accentBorder} shadow-soft hover:shadow-honey transition-all duration-300 hover:-translate-y-1 rounded-3xl`}>
                   <CardContent className="p-0 flex flex-col">
                     {/* Icon on white - top of card, fills container */}
-                    <div className="bg-white rounded-t-3xl w-full h-48 sm:h-56 overflow-hidden relative group-hover:scale-[1.02] transition-transform duration-300">
+                    <div className="bg-white rounded-t-3xl w-full h-48 sm:h-56 overflow-hidden relative p-3 sm:p-4 group-hover:scale-[1.02] transition-transform duration-300">
                       <div className="absolute inset-0">
                         <FeatureIcon
                           src={feature.iconSrc}

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -154,18 +154,18 @@ export function Hero() {
             <h3 className="text-xl font-semibold text-charcoal-800 mb-8 text-center">
               Good to Know
             </h3>
-            <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-8">
+            <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-8">
               {goodToKnowItems.map((item, index) => (
                 <div
                   key={index}
                   className="flex flex-col bg-white rounded-2xl shadow-soft border border-primary-200/30 hover:shadow-medium transition-shadow overflow-hidden"
                 >
-                  <div className="w-full h-48 sm:h-56 bg-white overflow-hidden relative">
+                  <div className="w-full h-48 sm:h-56 bg-white overflow-hidden relative p-3 sm:p-4">
                     <Image
                       src={item.iconSrc}
                       alt=""
                       fill
-                      className="object-cover"
+                      className="object-contain p-2"
                       sizes="(max-width: 640px) 50vw, 25vw"
                     />
                   </div>


### PR DESCRIPTION
- Change object-cover to object-contain so icons display fully without cropping
- Add padding to icon containers for breathing room on small screens
- Make Good to Know grid 2-col on mobile with tighter gap for better fit
- Applied fix to Hero, Features, ValuesSection, and RulesAndWaiver components

https://claude.ai/code/session_012CpQDSF4qZBHgdqUv6f7fg