### PR TITLE
🎨 Match icon container background to icon cream-white (#FFFDF7)

### DIFF
--- a/src/components/about/RulesAndWaiver.tsx
+++ b/src/components/about/RulesAndWaiver.tsx
@@ -129,7 +129,7 @@ export function RulesAndWaiver() {
               <motion.div key={index} variants={fadeInUp}>
                 <Card padding="none" className="h-full border-2 border-primary-200/50 shadow-soft hover:shadow-honey transition-all duration-300 rounded-3xl overflow-hidden">
                   <CardContent className="p-0 flex flex-col">
-                    <div className="w-full h-40 sm:h-48 bg-white relative overflow-hidden p-3 sm:p-4">
+                    <div className="w-full h-40 sm:h-48 bg-primary-50 relative overflow-hidden p-3 sm:p-4">
                       <RuleSectionIcon src={section.iconSrc} alt={section.title} title={section.title} />
                     </div>
                     <div className="p-6">

--- a/src/components/about/ValuesSection.tsx
+++ b/src/components/about/ValuesSection.tsx
@@ -72,7 +72,7 @@ export function ValuesSection() {
             <motion.div key={index} variants={fadeInUp}>
               <Card padding="none" className={`h-full text-left group relative overflow-hidden ${value.accentColor} border-2 ${value.accentBorder} shadow-soft hover:shadow-honey transition-all duration-300 hover:-translate-y-1 rounded-3xl`}>
                 <CardContent className="p-0 flex flex-col">
-                  <div className="w-full h-48 sm:h-56 bg-white overflow-hidden relative p-3 sm:p-4">
+                  <div className="w-full h-48 sm:h-56 bg-primary-50 overflow-hidden relative p-3 sm:p-4">
                     <div className="absolute inset-0">
                       <ValueIcon src={value.iconSrc} alt={value.title} title={value.title} className="w-full h-full" />
                     </div>

--- a/src/components/home/Features.tsx
+++ b/src/components/home/Features.tsx
@@ -118,8 +118,8 @@ export function Features() {
               <motion.div key={index} variants={fadeInUp}>
                 <Card padding="none" className={`h-full text-left group relative overflow-hidden ${feature.accentColor} border-2 ${feature.accentBorder} shadow-soft hover:shadow-honey transition-all duration-300 hover:-translate-y-1 rounded-3xl`}>
                   <CardContent className="p-0 flex flex-col">
-                    {/* Icon on white - top of card, fills container */}
-                    <div className="bg-white rounded-t-3xl w-full h-48 sm:h-56 overflow-hidden relative p-3 sm:p-4 group-hover:scale-[1.02] transition-transform duration-300">
+                    {/* Icon area - top of card, fills container */}
+                    <div className="bg-primary-50 rounded-t-3xl w-full h-48 sm:h-56 overflow-hidden relative p-3 sm:p-4 group-hover:scale-[1.02] transition-transform duration-300">
                       <div className="absolute inset-0">
                         <FeatureIcon
                           src={feature.iconSrc}

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -160,7 +160,7 @@ export function Hero() {
                   key={index}
                   className="flex flex-col bg-white rounded-2xl shadow-soft border border-primary-200/30 hover:shadow-medium transition-shadow overflow-hidden"
                 >
-                  <div className="w-full h-48 sm:h-56 bg-white overflow-hidden relative p-3 sm:p-4">
+                  <div className="w-full h-48 sm:h-56 bg-primary-50 overflow-hidden relative p-3 sm:p-4">
                     <Image
                       src={item.iconSrc}
                       alt=""


### PR DESCRIPTION
Change bg-white to bg-primary-50 on all icon card containers so the background blends seamlessly with the icons' off-white background instead of showing a pure white gap around contained icons.

https://claude.ai/code/session_012CpQDSF4qZBHgdqUv6f7fg