### PR TITLE
🔒 Update admin PIN to 0297 for POS and party scheduler

### DIFF
--- a/src/app/api/stripe/sync/route.ts
+++ b/src/app/api/stripe/sync/route.ts
@@ -91,7 +91,7 @@ export async function POST(request: NextRequest) {
   try {
     // Check for staff PIN header (for POS staff mode)
     const staffPin = request.headers.get('x-staff-pin');
-    const isStaffMode = staffPin === '1234'; // Same PIN as POS staff mode
+    const isStaffMode = staffPin === '0297'; // Same PIN as POS staff mode
 
     if (!isStaffMode) {
       // Verify admin access via Supabase auth

--- a/src/components/pos/AdminPanel.tsx
+++ b/src/components/pos/AdminPanel.tsx
@@ -450,7 +450,7 @@ export function AdminPanel({
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'x-staff-pin': '1234', // Staff mode authorization
+          'x-staff-pin': '0297', // Staff mode authorization
         },
       });
       if (response.ok) {

--- a/supabase/migrations/004_add_settings_table.sql
+++ b/supabase/migrations/004_add_settings_table.sql
@@ -42,6 +42,6 @@ INSERT INTO public.settings (key, value, description, is_encrypted) VALUES
   ('stripe_webhook_secret', '', 'Stripe webhook signing secret (starts with whsec_)', true),
   ('maintenance_mode', 'false', 'Enable maintenance mode to prevent customer access', false),
   ('closing_time', '20:00', 'Default closing time for auto-checkout (HH:MM)', false),
-  ('staff_pin', '1234', 'Default staff PIN for quick access (change this!)', true)
+  ('staff_pin', '0297', 'Default staff PIN for quick access (change this!)', true)
 ON CONFLICT (key) DO NOTHING;
 


### PR DESCRIPTION
Updates the hardcoded staff PIN from 1234 to 0297 across:
- Database migration default setting
- Stripe sync API staff mode check
- AdminPanel Stripe sync header

Resolves #211

https://claude.ai/code/session_016wbjiCkANCpzqa9emc4m3a