### PR TITLE
🐛 Re-enable My Account link in desktop header navigation

### DIFF
--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -31,5 +31,5 @@ export const ACCOUNT_ACCESS_ENABLED = true;
  * This is separate from ACCOUNT_ACCESS_ENABLED so you can enable access
  * (for testing via direct URL) without showing it in the navigation yet.
  */
-export const SHOW_ACCOUNT_IN_HEADER = false;
+export const SHOW_ACCOUNT_IN_HEADER = true;
 


### PR DESCRIPTION
Set SHOW_ACCOUNT_IN_HEADER feature flag to true so the My Account / Login
link is visible in the desktop navigation bar again.

Fixes #205

https://claude.ai/code/session_01Hcmcnwta7bypoiMrHUUDqn