### PR TITLE
✨ Add Group Rate package with $12/child pricing (min 10, max 30)

### DIFF
--- a/src/app/admin/parties/page.tsx
+++ b/src/app/admin/parties/page.tsx
@@ -39,6 +39,7 @@ const PACKAGE_LABELS = {
   queen_bee: 'Queen Bee',
   worker_bee: 'Worker Bee',
   basic_bee: 'Basic Bee',
+  group_rate: 'Group Rate',
 };
 
 export default function AdminPartiesPage() {

--- a/src/app/api/admin/party-packages/route.ts
+++ b/src/app/api/admin/party-packages/route.ts
@@ -10,33 +10,23 @@ import { logger } from '@/lib/logger';
 import { PACKAGE_PRICING } from '@/lib/validations/party-booking';
 import { z } from 'zod';
 
+const StandardPackageSchema = z.object({
+  name: z.string(),
+  semiPrivatePrice: z.number().min(0),
+  privatePrice: z.number().min(0),
+  maxGuests: z.number().min(1),
+  duration: z.number().min(1),
+  description: z.string(),
+  features: z.array(z.string()),
+});
+
 const PackageConfigSchema = z.object({
-  queen_bee: z.object({
-    name: z.string(),
-    semiPrivatePrice: z.number().min(0),
-    privatePrice: z.number().min(0),
-    maxGuests: z.number().min(1),
-    duration: z.number().min(1),
-    description: z.string(),
-    features: z.array(z.string()),
-  }),
-  worker_bee: z.object({
-    name: z.string(),
-    semiPrivatePrice: z.number().min(0),
-    privatePrice: z.number().min(0),
-    maxGuests: z.number().min(1),
-    duration: z.number().min(1),
-    description: z.string(),
-    features: z.array(z.string()),
-  }),
-  basic_bee: z.object({
-    name: z.string(),
-    semiPrivatePrice: z.number().min(0),
-    privatePrice: z.number().min(0),
-    maxGuests: z.number().min(1),
-    duration: z.number().min(1),
-    description: z.string(),
-    features: z.array(z.string()),
+  queen_bee: StandardPackageSchema,
+  worker_bee: StandardPackageSchema,
+  basic_bee: StandardPackageSchema,
+  group_rate: StandardPackageSchema.extend({
+    minGuests: z.number().min(1),
+    pricePerChild: z.number().min(0),
   }),
 });
 

--- a/src/app/api/party-booking/create/route.ts
+++ b/src/app/api/party-booking/create/route.ts
@@ -6,7 +6,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import * as Sentry from '@sentry/nextjs';
 import { createPartyBooking, updateBookingWithStripeSession } from '@/lib/services/party-bookings';
-import { CompleteBookingSchema, calculateBookingPrice, PACKAGE_PRICING } from '@/lib/validations/party-booking';
+import { CompleteBookingSchema, calculateBookingPrice, PACKAGE_PRICING, GROUP_RATE_PRICE_PER_CHILD } from '@/lib/validations/party-booking';
 import { createCheckoutSession } from '@/lib/stripe/checkout';
 import { createClient } from '@/lib/supabase/server';
 import { logger } from '@/lib/logger';
@@ -127,17 +127,27 @@ export async function POST(request: NextRequest) {
     });
 
     // Build line items for Stripe
-    const lineItems = [
-      {
-        price: pricing.basePrice,
-        quantity: 1,
-        name: `${packageInfo.name} Party Package`,
-        description: `${bookingData.partyType === 'private' ? 'Private' : 'Semi-Private'} party on ${formattedDate} at ${formatTime(bookingData.startTime)}`,
-      },
-    ];
+    const isGroupRate = bookingData.packageName === 'group_rate';
+    const lineItems = isGroupRate
+      ? [
+          {
+            price: GROUP_RATE_PRICE_PER_CHILD,
+            quantity: bookingData.guestCount,
+            name: `${packageInfo.name} — Group Admission`,
+            description: `${bookingData.guestCount} children on ${formattedDate} at ${formatTime(bookingData.startTime)}`,
+          },
+        ]
+      : [
+          {
+            price: pricing.basePrice,
+            quantity: 1,
+            name: `${packageInfo.name} Party Package`,
+            description: `${bookingData.partyType === 'private' ? 'Private' : 'Semi-Private'} party on ${formattedDate} at ${formatTime(bookingData.startTime)}`,
+          },
+        ];
 
-    // Add additional kids if any
-    if (pricing.additionalKids > 0) {
+    // Add additional kids if any (standard packages only)
+    if (!isGroupRate && pricing.additionalKids > 0) {
       lineItems.push({
         price: 15, // $15 per additional kid
         quantity: pricing.additionalKids,

--- a/src/components/info/PricingDetails.tsx
+++ b/src/components/info/PricingDetails.tsx
@@ -86,9 +86,9 @@ const additionalServices = [
   {
     icon: Users,
     title: 'Group Rates',
-    description: 'Homeschool & daycare groups (10+ children)',
-    price: 'Contact us',
-    note: 'Special pricing available'
+    description: 'Homeschool & daycare groups (10-30 children)',
+    price: '$12/child',
+    note: '$120 min (10 kids) — $360 max (30 kids)'
   }
 ]
 

--- a/src/components/parties/PartyBookingWizard.tsx
+++ b/src/components/parties/PartyBookingWizard.tsx
@@ -17,6 +17,10 @@ import {
   PackageName,
   calculateBookingPrice,
   PACKAGE_PRICING,
+  GROUP_RATE_MIN_CHILDREN,
+  GROUP_RATE_MAX_CHILDREN,
+  MAX_CHILDREN,
+  INCLUDED_KIDS,
 } from '@/lib/validations/party-booking';
 
 interface PartyBookingWizardProps {
@@ -82,7 +86,23 @@ export function PartyBookingWizard({ onClose, onSuccess }: PartyBookingWizardPro
   const [stepValid, setStepValid] = useState(false);
 
   const updateFormData = useCallback((updates: Partial<BookingFormData>) => {
-    setFormData((prev) => ({ ...prev, ...updates }));
+    setFormData((prev) => {
+      const next = { ...prev, ...updates };
+
+      // Adjust guest count when switching packages
+      if (updates.packageName && updates.packageName !== prev.packageName) {
+        if (updates.packageName === 'group_rate') {
+          // Set to group rate default/minimum of 10
+          next.guestCount = GROUP_RATE_MIN_CHILDREN;
+        } else if (prev.packageName === 'group_rate') {
+          // Switching from group rate to standard — clamp to standard default
+          next.guestCount = Math.min(next.guestCount, MAX_CHILDREN);
+          if (next.guestCount < 1) next.guestCount = INCLUDED_KIDS;
+        }
+      }
+
+      return next;
+    });
     setError(null);
   }, []);
 

--- a/src/components/parties/PartyPackages.tsx
+++ b/src/components/parties/PartyPackages.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { motion } from 'framer-motion'
-import { Gift, Users, Crown, Sparkles, Star, CheckCircle } from 'lucide-react'
+import { Gift, Users, Crown, Sparkles, Star, CheckCircle, DollarSign } from 'lucide-react'
 import { HoneycombPattern } from '@/components/ui/BeeIcon'
 import { Card, CardContent } from '@/components/ui/Card'
 import { Button } from '@/components/ui/Button'
@@ -78,6 +78,29 @@ const partyPackages = [
       'Dedicated party host assistance'
     ],
     popular: false
+  },
+  {
+    name: 'Group Rate',
+    description: 'Homeschool & daycare groups (10-30 children)',
+    icon: Users,
+    color: 'from-green-200 to-green-300',
+    borderColor: 'border-green-300',
+    accentColor: 'from-green-500 to-green-600',
+    semiPrivatePrice: 12,
+    privatePrice: 12,
+    maxGuests: 30,
+    duration: '2 hours',
+    isPerChild: true,
+    minGuests: 10,
+    features: [
+      '$12 per child',
+      'Minimum 10 children required',
+      'Maximum 30 children',
+      'Access to play area',
+      'Group coordinator assistance',
+      'Flexible scheduling'
+    ],
+    popular: false
   }
 ]
 
@@ -109,7 +132,7 @@ export function PartyPackages() {
 
         {/* Package Cards */}
         <motion.div
-          className="grid lg:grid-cols-3 gap-8 mb-12"
+          className="grid md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12"
           variants={staggerContainer}
           initial="hidden"
           whileInView="visible"
@@ -148,7 +171,9 @@ export function PartyPackages() {
                       <div className="flex justify-center items-center space-x-4">
                         <div className="flex items-center space-x-1">
                           <Users className="w-4 h-4 text-honey-600" />
-                          <span className="text-sm text-charcoal-600">{pkg.maxGuests} guests</span>
+                          <span className="text-sm text-charcoal-600">
+                            {pkg.isPerChild ? `${pkg.minGuests}-${pkg.maxGuests}` : pkg.maxGuests} guests
+                          </span>
                         </div>
                         <div className="w-1 h-1 bg-charcoal-400 rounded-full"></div>
                         <span className="text-sm text-charcoal-600">{pkg.duration}</span>
@@ -158,14 +183,31 @@ export function PartyPackages() {
                     {/* Pricing Section */}
                     <div className="text-center mb-8">
                       <div className="space-y-3">
-                        <div className="flex justify-between items-center p-3 bg-white/70 rounded-lg">
-                          <span className="font-medium text-charcoal-700">Private:</span>
-                          <span className="text-2xl font-bold text-charcoal-800">${pkg.privatePrice}</span>
-                        </div>
-                        <div className="flex justify-between items-center p-3 bg-white/70 rounded-lg">
-                          <span className="font-medium text-charcoal-700">Semi-Private:</span>
-                          <span className="text-2xl font-bold text-charcoal-800">${pkg.semiPrivatePrice}</span>
-                        </div>
+                        {pkg.isPerChild ? (
+                          <>
+                            <div className="flex justify-between items-center p-3 bg-white/70 rounded-lg">
+                              <span className="font-medium text-charcoal-700">Per Child:</span>
+                              <span className="text-2xl font-bold text-charcoal-800">${pkg.semiPrivatePrice}</span>
+                            </div>
+                            <div className="flex justify-between items-center p-3 bg-white/70 rounded-lg">
+                              <span className="font-medium text-charcoal-700">Range:</span>
+                              <span className="text-lg font-bold text-charcoal-800">
+                                ${pkg.minGuests * pkg.semiPrivatePrice} - ${pkg.maxGuests * pkg.semiPrivatePrice}
+                              </span>
+                            </div>
+                          </>
+                        ) : (
+                          <>
+                            <div className="flex justify-between items-center p-3 bg-white/70 rounded-lg">
+                              <span className="font-medium text-charcoal-700">Private:</span>
+                              <span className="text-2xl font-bold text-charcoal-800">${pkg.privatePrice}</span>
+                            </div>
+                            <div className="flex justify-between items-center p-3 bg-white/70 rounded-lg">
+                              <span className="font-medium text-charcoal-700">Semi-Private:</span>
+                              <span className="text-2xl font-bold text-charcoal-800">${pkg.semiPrivatePrice}</span>
+                            </div>
+                          </>
+                        )}
                       </div>
                     </div>
 

--- a/src/components/parties/booking-steps/GuestInfoStep.tsx
+++ b/src/components/parties/booking-steps/GuestInfoStep.tsx
@@ -8,6 +8,9 @@ import {
   ADDITIONAL_KIDS_PRICE,
   INCLUDED_KIDS,
   MAX_CHILDREN,
+  GROUP_RATE_PRICE_PER_CHILD,
+  GROUP_RATE_MIN_CHILDREN,
+  GROUP_RATE_MAX_CHILDREN,
   calculateBookingPrice,
 } from '@/lib/validations/party-booking';
 import type { BookingFormData } from '../PartyBookingWizard';
@@ -21,24 +24,30 @@ interface GuestInfoStepProps {
 export function GuestInfoStep({ formData, onUpdate, onValidChange }: GuestInfoStepProps) {
   const [errors, setErrors] = useState<Record<string, string>>({});
 
+  const isGroupRate = formData.packageName === 'group_rate';
+  const minGuests = isGroupRate ? GROUP_RATE_MIN_CHILDREN : 1;
+  const maxGuests = isGroupRate ? GROUP_RATE_MAX_CHILDREN : MAX_CHILDREN;
+
   // Validate step
   useEffect(() => {
     const newErrors: Record<string, string> = {};
 
     // Child name is optional - waivers signed when party arrives
 
-    if (formData.guestCount < 1) {
-      newErrors.guestCount = 'At least 1 guest is required';
-    } else if (formData.guestCount > MAX_CHILDREN) {
-      newErrors.guestCount = `Maximum ${MAX_CHILDREN} children allowed`;
+    if (formData.guestCount < minGuests) {
+      newErrors.guestCount = isGroupRate
+        ? `Minimum ${GROUP_RATE_MIN_CHILDREN} children required for group rate`
+        : 'At least 1 guest is required';
+    } else if (formData.guestCount > maxGuests) {
+      newErrors.guestCount = `Maximum ${maxGuests} children allowed`;
     }
 
     setErrors(newErrors);
     onValidChange(Object.keys(newErrors).length === 0);
-  }, [formData.childName, formData.guestCount, onValidChange]);
+  }, [formData.childName, formData.guestCount, formData.packageName, onValidChange, minGuests, maxGuests, isGroupRate]);
 
   const handleGuestCountChange = (delta: number) => {
-    const newCount = Math.max(1, Math.min(MAX_CHILDREN, formData.guestCount + delta));
+    const newCount = Math.max(minGuests, Math.min(maxGuests, formData.guestCount + delta));
     onUpdate({ guestCount: newCount });
   };
 
@@ -104,7 +113,7 @@ export function GuestInfoStep({ formData, onUpdate, onValidChange }: GuestInfoSt
             type="button"
             variant="outline"
             onClick={() => handleGuestCountChange(-1)}
-            disabled={formData.guestCount <= 1}
+            disabled={formData.guestCount <= minGuests}
             className="w-12 h-12 rounded-full"
           >
             <Minus className="w-5 h-5" />
@@ -119,7 +128,7 @@ export function GuestInfoStep({ formData, onUpdate, onValidChange }: GuestInfoSt
             type="button"
             variant="outline"
             onClick={() => handleGuestCountChange(1)}
-            disabled={formData.guestCount >= MAX_CHILDREN}
+            disabled={formData.guestCount >= maxGuests}
             className="w-12 h-12 rounded-full"
           >
             <Plus className="w-5 h-5" />
@@ -130,18 +139,27 @@ export function GuestInfoStep({ formData, onUpdate, onValidChange }: GuestInfoSt
         {pricing && (
           <div className="mt-6 pt-6 border-t">
             <div className="space-y-2 text-sm">
-              <div className="flex justify-between text-gray-600">
-                <span>Included children (up to {INCLUDED_KIDS})</span>
-                <span>Included</span>
-              </div>
-
-              {pricing.additionalKids > 0 && (
-                <div className="flex justify-between text-amber-700">
-                  <span>
-                    Additional children ({pricing.additionalKids} × ${ADDITIONAL_KIDS_PRICE})
-                  </span>
-                  <span>+${pricing.additionalKidsPrice}</span>
+              {isGroupRate ? (
+                <div className="flex justify-between text-gray-600">
+                  <span>{formData.guestCount} children × ${GROUP_RATE_PRICE_PER_CHILD}</span>
+                  <span>${pricing.totalPrice}</span>
                 </div>
+              ) : (
+                <>
+                  <div className="flex justify-between text-gray-600">
+                    <span>Included children (up to {INCLUDED_KIDS})</span>
+                    <span>Included</span>
+                  </div>
+
+                  {pricing.additionalKids > 0 && (
+                    <div className="flex justify-between text-amber-700">
+                      <span>
+                        Additional children ({pricing.additionalKids} × ${ADDITIONAL_KIDS_PRICE})
+                      </span>
+                      <span>+${pricing.additionalKidsPrice}</span>
+                    </div>
+                  )}
+                </>
               )}
             </div>
           </div>
@@ -173,9 +191,18 @@ export function GuestInfoStep({ formData, onUpdate, onValidChange }: GuestInfoSt
 
       <div className="p-4 bg-green-50 rounded-lg border border-green-200">
         <p className="text-sm text-green-800">
-          <strong>{INCLUDED_KIDS} children are included</strong> with your package. Each
-          additional child is ${ADDITIONAL_KIDS_PRICE} (maximum {MAX_CHILDREN} children total).
-          The birthday child counts toward your guest total.
+          {isGroupRate ? (
+            <>
+              <strong>Group Rate: ${GROUP_RATE_PRICE_PER_CHILD} per child.</strong> Minimum {GROUP_RATE_MIN_CHILDREN} children,
+              maximum {GROUP_RATE_MAX_CHILDREN} children.
+            </>
+          ) : (
+            <>
+              <strong>{INCLUDED_KIDS} children are included</strong> with your package. Each
+              additional child is ${ADDITIONAL_KIDS_PRICE} (maximum {MAX_CHILDREN} children total).
+              The birthday child counts toward your guest total.
+            </>
+          )}
         </p>
       </div>
     </div>

--- a/src/components/parties/booking-steps/PackageStep.tsx
+++ b/src/components/parties/booking-steps/PackageStep.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Gift, Sparkles, Crown, Users, CheckCircle, Star } from 'lucide-react';
 import { Card } from '@/components/ui/Card';
-import { PackageName, PACKAGE_PRICING } from '@/lib/validations/party-booking';
+import { PackageName, PACKAGE_PRICING, GROUP_RATE_PRICE_PER_CHILD } from '@/lib/validations/party-booking';
 import type { BookingFormData } from '../PartyBookingWizard';
 
 interface PackageStepProps {
@@ -41,6 +41,15 @@ const packages = [
     bgColor: 'bg-pink-50',
     popular: false,
   },
+  {
+    id: 'group_rate' as PackageName,
+    name: 'Group Rate',
+    icon: Users,
+    color: 'from-green-200 to-green-300',
+    borderColor: 'border-green-400',
+    bgColor: 'bg-green-50',
+    popular: false,
+  },
 ];
 
 export function PackageStep({ formData, onUpdate, onValidChange }: PackageStepProps) {
@@ -61,13 +70,15 @@ export function PackageStep({ formData, onUpdate, onValidChange }: PackageStepPr
         </p>
       </div>
 
-      <div className="grid md:grid-cols-3 gap-6">
+      <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
         {packages.map((pkg) => {
           const Icon = pkg.icon;
           const pricing = PACKAGE_PRICING[pkg.id];
           const isSelected = formData.packageName === pkg.id;
-          const displayPrice =
-            formData.partyType === 'private' ? pricing.privatePrice : pricing.semiPrivatePrice;
+          const isGroupRate = pkg.id === 'group_rate';
+          const displayPrice = isGroupRate
+            ? GROUP_RATE_PRICE_PER_CHILD
+            : formData.partyType === 'private' ? pricing.privatePrice : pricing.semiPrivatePrice;
 
           return (
             <motion.div
@@ -115,12 +126,14 @@ export function PackageStep({ formData, onUpdate, onValidChange }: PackageStepPr
                   <div className="text-center">
                     <div className="text-3xl font-bold text-charcoal-800">${displayPrice}</div>
                     <div className="text-sm text-gray-500">
-                      {formData.partyType === 'private' ? 'Private' : 'Semi-Private'}
+                      {isGroupRate ? 'per child' : formData.partyType === 'private' ? 'Private' : 'Semi-Private'}
                     </div>
                   </div>
                   <div className="flex items-center justify-center mt-2 text-sm text-gray-600">
                     <Users className="w-4 h-4 mr-1" />
-                    Up to {pricing.maxGuests} guests • {pricing.duration} hours
+                    {isGroupRate
+                      ? `${pricing.minGuests}-${pricing.maxGuests} children • ${pricing.duration} hours`
+                      : `Up to ${pricing.maxGuests} guests • ${pricing.duration} hours`}
                   </div>
                 </div>
 
@@ -146,7 +159,15 @@ export function PackageStep({ formData, onUpdate, onValidChange }: PackageStepPr
 
       <div className="p-4 bg-green-50 rounded-lg border border-green-200">
         <p className="text-sm text-green-800">
-          <strong>15 kids included</strong> with all packages. Additional kids are $15 each (max 20 children total).
+          {formData.packageName === 'group_rate' ? (
+            <>
+              <strong>Group Rate: ${GROUP_RATE_PRICE_PER_CHILD}/child</strong> — minimum 10, maximum 30 children.
+            </>
+          ) : (
+            <>
+              <strong>15 kids included</strong> with all packages. Additional kids are $15 each (max 20 children total).
+            </>
+          )}
         </p>
       </div>
     </div>

--- a/src/components/parties/booking-steps/ReviewStep.tsx
+++ b/src/components/parties/booking-steps/ReviewStep.tsx
@@ -15,7 +15,7 @@ import {
   CreditCard,
 } from 'lucide-react';
 import { Card } from '@/components/ui/Card';
-import { PACKAGE_PRICING } from '@/lib/validations/party-booking';
+import { PACKAGE_PRICING, GROUP_RATE_PRICE_PER_CHILD } from '@/lib/validations/party-booking';
 import { parseDateString } from '@/lib/utils';
 import type { BookingFormData } from '../PartyBookingWizard';
 
@@ -54,6 +54,7 @@ export function ReviewStep({ formData, pricing, onValidChange }: ReviewStepProps
   };
 
   const packageInfo = formData.packageName ? PACKAGE_PRICING[formData.packageName] : null;
+  const isGroupRate = formData.packageName === 'group_rate';
 
   return (
     <div className="space-y-6">
@@ -143,16 +144,18 @@ export function ReviewStep({ formData, pricing, onValidChange }: ReviewStepProps
           <div className="flex justify-between items-start">
             <div>
               <div className="font-semibold text-charcoal-800">
-                {packageInfo?.name || 'Package'} Package
+                {packageInfo?.name || 'Package'} {isGroupRate ? '' : 'Package'}
               </div>
               <div className="text-sm text-gray-600">
-                {formData.partyType === 'private' ? 'Private Party' : 'Semi-Private Party'}
+                {isGroupRate
+                  ? `${formData.guestCount} children × $${GROUP_RATE_PRICE_PER_CHILD}/child`
+                  : formData.partyType === 'private' ? 'Private Party' : 'Semi-Private Party'}
               </div>
             </div>
             <div className="text-right font-semibold">${pricing?.basePrice || 0}</div>
           </div>
 
-          {pricing && pricing.additionalKids > 0 && (
+          {!isGroupRate && pricing && pricing.additionalKids > 0 && (
             <div className="flex justify-between items-start text-amber-700">
               <div>
                 <div className="font-medium">Additional Children</div>

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -554,7 +554,7 @@ export interface Database {
           customer_phone: string;
           customer_address: string | null;
           party_type: 'private' | 'semi_private';
-          package_name: 'queen_bee' | 'worker_bee' | 'basic_bee';
+          package_name: 'queen_bee' | 'worker_bee' | 'basic_bee' | 'group_rate';
           party_date: string;
           start_time: string;
           end_time: string;
@@ -587,7 +587,7 @@ export interface Database {
           customer_phone: string;
           customer_address?: string | null;
           party_type: 'private' | 'semi_private';
-          package_name: 'queen_bee' | 'worker_bee' | 'basic_bee';
+          package_name: 'queen_bee' | 'worker_bee' | 'basic_bee' | 'group_rate';
           party_date: string;
           start_time: string;
           end_time: string;

--- a/src/lib/validations/party-booking.ts
+++ b/src/lib/validations/party-booking.ts
@@ -18,7 +18,7 @@ export const PartyTypeSchema = z.enum(['private', 'semi_private'], {
 });
 
 // Package name enum (per issue requirements)
-export const PackageNameSchema = z.enum(['queen_bee', 'worker_bee', 'basic_bee'], {
+export const PackageNameSchema = z.enum(['queen_bee', 'worker_bee', 'basic_bee', 'group_rate'], {
   message: 'Please select a party package',
 });
 
@@ -69,7 +69,7 @@ export const DateTimeSelectionSchema = z.object({
   endTime: z.string().min(1, 'End time is required'),
 });
 
-// Guest count schema (Step 6) - Max 20 children per issue #101
+// Guest count schema (Step 6) - Max 20 children for standard packages, 30 for group rate
 export const GuestCountSchema = z.object({
   childName: z
     .string()
@@ -84,7 +84,7 @@ export const GuestCountSchema = z.object({
   guestCount: z
     .number()
     .min(1, 'At least 1 guest is required')
-    .max(20, 'Maximum 20 children allowed'),
+    .max(30, 'Maximum 30 children allowed'),
   additionalKids: z
     .number()
     .min(0, 'Additional kids cannot be negative')
@@ -122,7 +122,7 @@ export const CompleteBookingSchema = z.object({
   startTime: z.string().min(1, 'Please select a time slot'),
   endTime: z.string().min(1, 'End time is required'),
 
-  // Guest Info - Max 20 children per issue #101
+  // Guest Info - Max 20 children for standard packages, 30 for group rate
   // Child info is optional - waivers signed when party arrives
   childName: z
     .string()
@@ -133,7 +133,7 @@ export const CompleteBookingSchema = z.object({
   guestCount: z
     .number()
     .min(1, 'At least 1 guest is required')
-    .max(20, 'Maximum 20 children allowed'),
+    .max(30, 'Maximum 30 children allowed'),
   additionalKids: z.number().min(0).max(5).default(0),
   notes: z.string().max(500).optional(),
 });
@@ -204,6 +204,24 @@ export const PACKAGE_PRICING = {
       'Party setup & breakdown handled',
     ],
   },
+  group_rate: {
+    name: 'Group Rate',
+    semiPrivatePrice: 120,
+    privatePrice: 120,
+    maxGuests: 30,
+    minGuests: 10,
+    pricePerChild: 12,
+    duration: 2,
+    description: 'Homeschool & daycare groups (10-30 children)',
+    features: [
+      '$12 per child',
+      'Minimum 10 children required',
+      'Maximum 30 children',
+      'Access to play area',
+      'Group coordinator assistance',
+      'Flexible scheduling',
+    ],
+  },
 } as const;
 
 // Time slots are now stored in the database (party_time_slots table)
@@ -211,8 +229,13 @@ export const PACKAGE_PRICING = {
 
 // Additional kids pricing - per issue #101
 export const ADDITIONAL_KIDS_PRICE = 15; // $15 per additional kid
-export const INCLUDED_KIDS = 15; // 15 kids included with each package
-export const MAX_CHILDREN = 20; // Maximum 20 children total per issue #101
+export const INCLUDED_KIDS = 15; // 15 kids included with each standard package
+export const MAX_CHILDREN = 20; // Maximum 20 children total for standard packages per issue #101
+
+// Group rate pricing - per issue #209
+export const GROUP_RATE_PRICE_PER_CHILD = 12; // $12 per child
+export const GROUP_RATE_MIN_CHILDREN = 10; // Minimum 10 children
+export const GROUP_RATE_MAX_CHILDREN = 30; // Maximum 30 children
 
 /**
  * Calculate total price for a party booking
@@ -222,6 +245,17 @@ export function calculateBookingPrice(
   partyType: PartyType,
   guestCount: number
 ): { basePrice: number; additionalKidsPrice: number; totalPrice: number; additionalKids: number } {
+  // Group rate uses per-child pricing with no additional kids concept
+  if (packageName === 'group_rate') {
+    const totalPrice = guestCount * GROUP_RATE_PRICE_PER_CHILD;
+    return {
+      basePrice: totalPrice,
+      additionalKidsPrice: 0,
+      totalPrice,
+      additionalKids: 0,
+    };
+  }
+
   const packageInfo = PACKAGE_PRICING[packageName];
   const basePrice = partyType === 'private' ? packageInfo.privatePrice : packageInfo.semiPrivatePrice;
 

--- a/supabase/migrations/026_add_group_rate_package.sql
+++ b/supabase/migrations/026_add_group_rate_package.sql
@@ -1,0 +1,7 @@
+-- Add group_rate to party_package_name enum
+-- Per issue #209: Group Rate package with $12/child, min 10, max 30
+ALTER TYPE party_package_name ADD VALUE IF NOT EXISTS 'group_rate';
+
+-- Update the guest count constraint to allow up to 30 for group rate bookings
+ALTER TABLE party_bookings DROP CONSTRAINT IF EXISTS valid_guest_count;
+ALTER TABLE party_bookings ADD CONSTRAINT valid_guest_count CHECK (guest_count >= 1 AND guest_count <= 50);


### PR DESCRIPTION
Resolves #209 — adds a bookable Group Rate party package for
homeschool & daycare groups priced at $12 per child with a
minimum of 10 children ($120) and maximum of 30 children ($360).

- Add group_rate to PackageNameSchema, PACKAGE_PRICING, and
  database enum/types
- Per-child pricing in calculateBookingPrice (no base+additional model)
- Booking wizard: package card, guest count defaults/constraints,
  review step with per-child breakdown
- Stripe checkout creates per-child line items for group bookings
- Admin labels, API schema validation, and pricing display updated
- New migration 026 adds group_rate to party_package_name enum

https://claude.ai/code/session_01KuypCqTiwpXAxbVXkdYKK7