### PR TITLE
🐛 Fix password reset email not sending with proper user feedback

### DIFF
--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -66,6 +66,16 @@ export async function POST(request: NextRequest) {
       }, { status: 200 });
     }
 
+    // Check if user has an email address on file
+    if (!user.email || user.email.trim() === '') {
+      console.error('Password reset requested but user has no email on file:', user.id);
+      return NextResponse.json({
+        message: 'If an account exists with that phone number, you will receive a password reset email.',
+        success: true,
+        noEmail: true
+      }, { status: 200 });
+    }
+
     // Generate secure random token
     const resetToken = crypto.randomBytes(32).toString('hex');
     const expiresAt = new Date(Date.now() + TOKEN_EXPIRY_HOURS * 60 * 60 * 1000);
@@ -103,7 +113,11 @@ export async function POST(request: NextRequest) {
 
     if (!emailResult.success) {
       console.error('Failed to send password reset email:', emailResult.error);
-      // Still return success to prevent enumeration
+      return NextResponse.json({
+        message: 'If an account exists with that phone number, you will receive a password reset email.',
+        success: true,
+        emailFailed: true
+      }, { status: 200 });
     }
 
     return NextResponse.json({

--- a/src/app/customer/forgot-password/page.tsx
+++ b/src/app/customer/forgot-password/page.tsx
@@ -17,6 +17,8 @@ export default function ForgotPasswordPage() {
   const [error, setError] = useState('');
   const [success, setSuccess] = useState(false);
   const [needsPasswordSetup, setNeedsPasswordSetup] = useState(false);
+  const [noEmail, setNoEmail] = useState(false);
+  const [emailFailed, setEmailFailed] = useState(false);
 
   const formatPhoneNumber = (value: string) => {
     const phoneNumber = value.replace(/[^\d]/g, '');
@@ -34,6 +36,8 @@ export default function ForgotPasswordPage() {
     setPhone(formatted);
     setError('');
     setNeedsPasswordSetup(false);
+    setNoEmail(false);
+    setEmailFailed(false);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -42,6 +46,8 @@ export default function ForgotPasswordPage() {
     setError('');
     setSuccess(false);
     setNeedsPasswordSetup(false);
+    setNoEmail(false);
+    setEmailFailed(false);
 
     try {
       const response = await fetch('/api/auth/forgot-password', {
@@ -60,6 +66,10 @@ export default function ForgotPasswordPage() {
 
       if (data.needsPasswordSetup) {
         setNeedsPasswordSetup(true);
+      } else if (data.noEmail) {
+        setNoEmail(true);
+      } else if (data.emailFailed) {
+        setEmailFailed(true);
       } else {
         setSuccess(true);
       }
@@ -142,6 +152,20 @@ export default function ForgotPasswordPage() {
                     >
                       Click here to set up your password
                     </Link>
+                  </div>
+                )}
+
+                {noEmail && (
+                  <div className="bg-yellow-50 border border-yellow-200 text-yellow-800 px-4 py-3 rounded-lg text-sm">
+                    <p className="mb-2">We don&apos;t have an email address on file for your account, so we&apos;re unable to send a reset link.</p>
+                    <p>Please contact us at <a href="mailto:info@busybeesipc.com" className="text-yellow-700 hover:text-yellow-900 font-medium underline">info@busybeesipc.com</a> or visit our front desk to update your email and reset your password.</p>
+                  </div>
+                )}
+
+                {emailFailed && (
+                  <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg text-sm">
+                    <p className="mb-2">We were unable to send the password reset email. Please try again in a few minutes.</p>
+                    <p>If the problem persists, contact us at <a href="mailto:info@busybeesipc.com" className="text-red-600 hover:text-red-800 font-medium underline">info@busybeesipc.com</a> for assistance.</p>
                   </div>
                 )}
 


### PR DESCRIPTION
Previously, when a user requested a password reset, the API would:
1. Attempt to send an email to a null/empty address if the user had no
   email on file, causing a silent failure
2. Always show "Check your email" even when email sending failed

Now the API validates the user has an email before attempting to send,
and returns distinct flags (noEmail, emailFailed) so the frontend can
show actionable messages instead of a misleading success screen.

Closes #204

https://claude.ai/code/session_01KniXudCshqzhZuu5YePE78