### PR TITLE
✨ Add newsletter email sending with compose UI and test send

### DIFF
--- a/src/app/api/newsletter/send/route.ts
+++ b/src/app/api/newsletter/send/route.ts
@@ -1,0 +1,126 @@
+/**
+ * API Route: Send Newsletter
+ * POST - Send a newsletter email to all active subscribers
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createAdminClient } from '@/lib/supabase/server';
+import { sendNewsletterEmail } from '@/lib/email/resend';
+import { logger } from '@/lib/logger';
+import { z } from 'zod';
+
+const sendNewsletterSchema = z.object({
+  subject: z.string().min(1, 'Subject is required').max(200, 'Subject too long'),
+  heading: z.string().min(1, 'Heading is required').max(200, 'Heading too long'),
+  body: z.string().min(1, 'Body content is required').max(10000, 'Body content too long'),
+  ctaText: z.string().max(100, 'Button text too long').optional(),
+  ctaUrl: z.string().url('Invalid button URL').optional(),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+
+    // Validate request body
+    const validationResult = sendNewsletterSchema.safeParse(body);
+    if (!validationResult.success) {
+      const errorMessages = validationResult.error.issues.map((issue) => issue.message).join(', ');
+      return NextResponse.json(
+        { error: errorMessages },
+        { status: 400 }
+      );
+    }
+
+    const { subject, heading, body: bodyContent, ctaText, ctaUrl } = validationResult.data;
+
+    // If CTA text is provided, URL must also be provided (and vice versa)
+    if ((ctaText && !ctaUrl) || (!ctaText && ctaUrl)) {
+      return NextResponse.json(
+        { error: 'Both button text and URL must be provided together' },
+        { status: 400 }
+      );
+    }
+
+    // Fetch all active subscribers
+    const supabase = createAdminClient();
+    const { data: subscribers, error: fetchError } = await supabase
+      .from('newsletter_subscribers')
+      .select('email, name')
+      .eq('is_active', true);
+
+    if (fetchError) {
+      logger.error({ error: fetchError }, 'Failed to fetch active subscribers for newsletter send');
+      return NextResponse.json(
+        { error: 'Failed to fetch subscribers' },
+        { status: 500 }
+      );
+    }
+
+    if (!subscribers || subscribers.length === 0) {
+      return NextResponse.json(
+        { error: 'No active subscribers to send to' },
+        { status: 400 }
+      );
+    }
+
+    logger.info(
+      { subscriberCount: subscribers.length, subject },
+      '📨 Starting newsletter send'
+    );
+
+    // Send to each subscriber with a small delay to avoid rate limits
+    let sent = 0;
+    let failed = 0;
+    const errors: Array<{ email: string; error: string }> = [];
+
+    for (const subscriber of subscribers) {
+      try {
+        const result = await sendNewsletterEmail({
+          to: subscriber.email,
+          subscriberName: subscriber.name || 'Friend',
+          subject,
+          heading,
+          body: bodyContent,
+          ctaText: ctaText || undefined,
+          ctaUrl: ctaUrl || undefined,
+          subscriberEmail: subscriber.email,
+        });
+
+        if (result.success) {
+          sent++;
+        } else {
+          failed++;
+          errors.push({ email: subscriber.email, error: result.error || 'Unknown error' });
+        }
+      } catch (error) {
+        failed++;
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        errors.push({ email: subscriber.email, error: errorMessage });
+      }
+
+      // Small delay between sends to avoid rate limiting (50ms)
+      if (sent + failed < subscribers.length) {
+        await new Promise(resolve => setTimeout(resolve, 50));
+      }
+    }
+
+    logger.info(
+      { sent, failed, total: subscribers.length, subject },
+      '📨 Newsletter send complete'
+    );
+
+    return NextResponse.json({
+      success: true,
+      sent,
+      failed,
+      total: subscribers.length,
+      errors: errors.length > 0 ? errors.slice(0, 10) : undefined,
+    });
+  } catch (error) {
+    logger.error({ error }, 'Newsletter send error');
+    return NextResponse.json(
+      { error: 'Failed to send newsletter' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/newsletter/test/route.ts
+++ b/src/app/api/newsletter/test/route.ts
@@ -1,0 +1,67 @@
+/**
+ * API Route: Send Test Newsletter
+ * POST - Send a test newsletter email to a single email address
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { sendNewsletterEmail } from '@/lib/email/resend';
+import { logger } from '@/lib/logger';
+import { z } from 'zod';
+
+const testNewsletterSchema = z.object({
+  testEmail: z.string().email('Invalid test email address'),
+  subject: z.string().min(1, 'Subject is required').max(200, 'Subject too long'),
+  heading: z.string().min(1, 'Heading is required').max(200, 'Heading too long'),
+  body: z.string().min(1, 'Body content is required').max(10000, 'Body content too long'),
+  ctaText: z.string().max(100, 'Button text too long').optional(),
+  ctaUrl: z.string().url('Invalid button URL').optional(),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+
+    const validationResult = testNewsletterSchema.safeParse(body);
+    if (!validationResult.success) {
+      const errorMessages = validationResult.error.issues.map((issue) => issue.message).join(', ');
+      return NextResponse.json(
+        { error: errorMessages },
+        { status: 400 }
+      );
+    }
+
+    const { testEmail, subject, heading, body: bodyContent, ctaText, ctaUrl } = validationResult.data;
+
+    logger.info(
+      { testEmail, subject },
+      '📨 Sending test newsletter email'
+    );
+
+    const result = await sendNewsletterEmail({
+      to: testEmail,
+      subscriberName: 'Test Subscriber',
+      subject: `[TEST] ${subject}`,
+      heading,
+      body: bodyContent,
+      ctaText: ctaText || undefined,
+      ctaUrl: ctaUrl || undefined,
+      subscriberEmail: testEmail,
+    });
+
+    if (result.success) {
+      logger.info({ testEmail, messageId: result.messageId }, '📨 Test newsletter sent successfully');
+      return NextResponse.json({ success: true, messageId: result.messageId });
+    }
+
+    return NextResponse.json(
+      { error: result.error || 'Failed to send test email' },
+      { status: 500 }
+    );
+  } catch (error) {
+    logger.error({ error }, 'Test newsletter send error');
+    return NextResponse.json(
+      { error: 'Failed to send test newsletter' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/newsletter/unsubscribe/route.ts
+++ b/src/app/api/newsletter/unsubscribe/route.ts
@@ -1,0 +1,46 @@
+/**
+ * API Route: Newsletter Unsubscribe
+ * POST - Unsubscribe an email from the newsletter
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { unsubscribeFromNewsletter } from '@/lib/services/newsletter';
+import { logger } from '@/lib/logger';
+import { z } from 'zod';
+
+const unsubscribeSchema = z.object({
+  email: z.string().email('Invalid email format'),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+
+    const validationResult = unsubscribeSchema.safeParse(body);
+    if (!validationResult.success) {
+      return NextResponse.json(
+        { error: 'Invalid email address' },
+        { status: 400 }
+      );
+    }
+
+    const { email } = validationResult.data;
+    const success = await unsubscribeFromNewsletter(email);
+
+    if (success) {
+      logger.info({ email }, '📧 Newsletter unsubscribe via link');
+      return NextResponse.json({ success: true });
+    }
+
+    return NextResponse.json(
+      { error: 'Failed to unsubscribe' },
+      { status: 500 }
+    );
+  } catch (error) {
+    logger.error({ error }, 'Newsletter unsubscribe error');
+    return NextResponse.json(
+      { error: 'Failed to process unsubscribe request' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/newsletter/unsubscribe/page.tsx
+++ b/src/app/newsletter/unsubscribe/page.tsx
@@ -1,0 +1,133 @@
+/**
+ * Newsletter Unsubscribe Page
+ * Allows subscribers to unsubscribe from the newsletter via link
+ */
+
+'use client';
+
+import { useState, useEffect, Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { Card } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+
+function UnsubscribeContent() {
+  const searchParams = useSearchParams();
+  const email = searchParams.get('email') || '';
+
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    if (!email) {
+      setStatus('error');
+      setMessage('No email address provided.');
+    }
+  }, [email]);
+
+  const handleUnsubscribe = async () => {
+    if (!email) return;
+
+    setStatus('loading');
+    try {
+      const response = await fetch('/api/newsletter/unsubscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+
+      if (response.ok) {
+        setStatus('success');
+        setMessage('You have been unsubscribed from our newsletter. We\'re sorry to see you go!');
+      } else {
+        setStatus('error');
+        setMessage('Something went wrong. Please try again or contact us.');
+      }
+    } catch {
+      setStatus('error');
+      setMessage('Something went wrong. Please try again or contact us.');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-pastel-cream to-pastel-yellow flex items-center justify-center p-4">
+      <Card className="max-w-md w-full p-8 text-center">
+        <div className="mb-6">
+          <div className="w-16 h-16 bg-yellow-100 rounded-full flex items-center justify-center mx-auto mb-4">
+            <span className="text-3xl">&#x1F41D;</span>
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900 mb-2">
+            Newsletter Unsubscribe
+          </h1>
+        </div>
+
+        {status === 'idle' && email && (
+          <div>
+            <p className="text-gray-600 mb-6">
+              Are you sure you want to unsubscribe <strong>{email}</strong> from the Busy Bees newsletter?
+            </p>
+            <div className="space-y-3">
+              <Button
+                onClick={handleUnsubscribe}
+                variant="outline"
+                className="w-full"
+              >
+                Yes, Unsubscribe Me
+              </Button>
+              <p className="text-xs text-gray-400">
+                You can always resubscribe from our website.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {status === 'loading' && (
+          <p className="text-gray-500">Processing your request...</p>
+        )}
+
+        {status === 'success' && (
+          <div>
+            <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
+              <span className="text-2xl">&#x2705;</span>
+            </div>
+            <p className="text-gray-600 mb-4">{message}</p>
+            <a
+              href="/"
+              className="text-sm text-yellow-600 hover:text-yellow-700 underline"
+            >
+              Visit Busy Bees
+            </a>
+          </div>
+        )}
+
+        {status === 'error' && (
+          <div>
+            <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
+              <span className="text-2xl">&#x274C;</span>
+            </div>
+            <p className="text-gray-600 mb-4">{message}</p>
+            <a
+              href="/"
+              className="text-sm text-yellow-600 hover:text-yellow-700 underline"
+            >
+              Visit Busy Bees
+            </a>
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}
+
+export default function UnsubscribePage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen bg-gradient-to-b from-pastel-cream to-pastel-yellow flex items-center justify-center p-4">
+        <Card className="max-w-md w-full p-8 text-center">
+          <p className="text-gray-500">Loading...</p>
+        </Card>
+      </div>
+    }>
+      <UnsubscribeContent />
+    </Suspense>
+  );
+}

--- a/src/components/pos/AdminPanel.tsx
+++ b/src/components/pos/AdminPanel.tsx
@@ -305,6 +305,26 @@ export function AdminPanel({
   const [newsletterLoading, setNewsletterLoading] = useState(false);
   const [newsletterSearchTerm, setNewsletterSearchTerm] = useState('');
 
+  // Newsletter compose states
+  const [showCompose, setShowCompose] = useState(false);
+  const [newsletterSubject, setNewsletterSubject] = useState('');
+  const [newsletterHeading, setNewsletterHeading] = useState('');
+  const [newsletterBody, setNewsletterBody] = useState('');
+  const [newsletterCtaText, setNewsletterCtaText] = useState('');
+  const [newsletterCtaUrl, setNewsletterCtaUrl] = useState('');
+  const [newsletterSending, setNewsletterSending] = useState(false);
+  const [newsletterSendResult, setNewsletterSendResult] = useState<{
+    success: boolean;
+    sent: number;
+    failed: number;
+    total: number;
+  } | null>(null);
+  const [showPreview, setShowPreview] = useState(false);
+  const [confirmSend, setConfirmSend] = useState(false);
+  const [testEmail, setTestEmail] = useState('');
+  const [testSending, setTestSending] = useState(false);
+  const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null);
+
   // Customer loading state
   const [customersLoading, setCustomersLoading] = useState(false);
   const [customersStats, setCustomersStats] = useState({ total: 0, withPurchases: 0, active: 0 });
@@ -3369,6 +3389,118 @@ export function AdminPanel({
     }
   };
 
+  const handleSendNewsletter = async () => {
+    if (!confirmSend) {
+      setConfirmSend(true);
+      setTimeout(() => setConfirmSend(false), 5000);
+      return;
+    }
+
+    setConfirmSend(false);
+    setNewsletterSending(true);
+    setNewsletterSendResult(null);
+
+    try {
+      const payload: Record<string, string> = {
+        subject: newsletterSubject,
+        heading: newsletterHeading,
+        body: newsletterBody,
+      };
+      if (newsletterCtaText && newsletterCtaUrl) {
+        payload.ctaText = newsletterCtaText;
+        payload.ctaUrl = newsletterCtaUrl;
+      }
+
+      const response = await fetch('/api/newsletter/send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      const data = await response.json();
+
+      if (response.ok) {
+        setNewsletterSendResult({
+          success: true,
+          sent: data.sent,
+          failed: data.failed,
+          total: data.total,
+        });
+      } else {
+        setNewsletterSendResult({
+          success: false,
+          sent: 0,
+          failed: 0,
+          total: 0,
+        });
+      }
+    } catch (error) {
+      console.error('Failed to send newsletter:', error);
+      setNewsletterSendResult({
+        success: false,
+        sent: 0,
+        failed: 0,
+        total: 0,
+      });
+    } finally {
+      setNewsletterSending(false);
+    }
+  };
+
+  const handleSendTestNewsletter = async () => {
+    if (!testEmail || !isComposeValid) return;
+
+    setTestSending(true);
+    setTestResult(null);
+
+    try {
+      const payload: Record<string, string> = {
+        testEmail,
+        subject: newsletterSubject,
+        heading: newsletterHeading,
+        body: newsletterBody,
+      };
+      if (newsletterCtaText && newsletterCtaUrl) {
+        payload.ctaText = newsletterCtaText;
+        payload.ctaUrl = newsletterCtaUrl;
+      }
+
+      const response = await fetch('/api/newsletter/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      if (response.ok) {
+        setTestResult({ success: true, message: `Test email sent to ${testEmail}` });
+      } else {
+        const data = await response.json();
+        setTestResult({ success: false, message: data.error || 'Failed to send test email' });
+      }
+    } catch (error) {
+      console.error('Failed to send test newsletter:', error);
+      setTestResult({ success: false, message: 'Failed to send test email' });
+    } finally {
+      setTestSending(false);
+    }
+  };
+
+  const resetComposeForm = () => {
+    setNewsletterSubject('');
+    setNewsletterHeading('');
+    setNewsletterBody('');
+    setNewsletterCtaText('');
+    setNewsletterCtaUrl('');
+    setNewsletterSendResult(null);
+    setShowPreview(false);
+    setConfirmSend(false);
+    setShowCompose(false);
+    setTestEmail('');
+    setTestResult(null);
+  };
+
+  const isComposeValid = newsletterSubject.trim() && newsletterHeading.trim() && newsletterBody.trim();
+
   const renderNewsletter = () => {
     const filteredSubscribers = newsletterSubscribers.filter(sub =>
       sub.name.toLowerCase().includes(newsletterSearchTerm.toLowerCase()) ||
@@ -3407,6 +3539,278 @@ export function AdminPanel({
           </Card>
         </div>
 
+        {/* Send Newsletter Section */}
+        <Card className="p-6">
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <h3 className="text-lg font-semibold">Send Newsletter</h3>
+              <p className="text-sm text-gray-500">
+                Compose and send a newsletter to all {newsletterStats.active} active subscribers
+              </p>
+            </div>
+            {!showCompose && (
+              <Button
+                onClick={() => {
+                  setShowCompose(true);
+                  setNewsletterSendResult(null);
+                }}
+                size="sm"
+                disabled={newsletterStats.active === 0}
+              >
+                &#x270F;&#xFE0F; Compose Newsletter
+              </Button>
+            )}
+          </div>
+
+          {showCompose && (
+            <div className="space-y-4">
+              {/* Subject Line */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Email Subject Line
+                </label>
+                <input
+                  type="text"
+                  value={newsletterSubject}
+                  onChange={(e) => setNewsletterSubject(e.target.value)}
+                  placeholder="e.g. Exciting News from Busy Bees!"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-yellow-500 focus:border-transparent"
+                  maxLength={200}
+                />
+              </div>
+
+              {/* Heading */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Newsletter Heading
+                </label>
+                <input
+                  type="text"
+                  value={newsletterHeading}
+                  onChange={(e) => setNewsletterHeading(e.target.value)}
+                  placeholder="e.g. What's Buzzing This Month"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-yellow-500 focus:border-transparent"
+                  maxLength={200}
+                />
+                <p className="text-xs text-gray-400 mt-1">
+                  This appears as the main title in the email header
+                </p>
+              </div>
+
+              {/* Body Content */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Newsletter Content
+                </label>
+                <textarea
+                  value={newsletterBody}
+                  onChange={(e) => setNewsletterBody(e.target.value)}
+                  placeholder={"Write your newsletter content here...\n\nUse blank lines to separate paragraphs.\n\nShare updates, promotions, events, or any news with your subscribers!"}
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-yellow-500 focus:border-transparent min-h-[200px] resize-y"
+                  maxLength={10000}
+                />
+                <p className="text-xs text-gray-400 mt-1">
+                  {newsletterBody.length}/10,000 characters &middot; Use blank lines between paragraphs
+                </p>
+              </div>
+
+              {/* CTA Button (Optional) */}
+              <div className="bg-gray-50 rounded-lg p-4">
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  Call-to-Action Button <span className="text-gray-400 font-normal">(optional)</span>
+                </label>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                  <div>
+                    <input
+                      type="text"
+                      value={newsletterCtaText}
+                      onChange={(e) => setNewsletterCtaText(e.target.value)}
+                      placeholder="Button text, e.g. Book Now"
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-yellow-500 focus:border-transparent text-sm"
+                      maxLength={100}
+                    />
+                  </div>
+                  <div>
+                    <input
+                      type="url"
+                      value={newsletterCtaUrl}
+                      onChange={(e) => setNewsletterCtaUrl(e.target.value)}
+                      placeholder="Button URL, e.g. https://busybeesipc.com"
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-yellow-500 focus:border-transparent text-sm"
+                    />
+                  </div>
+                </div>
+                <p className="text-xs text-gray-400 mt-2">
+                  Add a button that links to your website, a booking page, or a promotion
+                </p>
+              </div>
+
+              {/* Preview Toggle */}
+              {isComposeValid && (
+                <div>
+                  <Button
+                    onClick={() => setShowPreview(!showPreview)}
+                    size="sm"
+                    variant="outline"
+                  >
+                    {showPreview ? '&#x1F4DD; Hide Preview' : '&#x1F441; Preview Email'}
+                  </Button>
+                </div>
+              )}
+
+              {/* Email Preview */}
+              {showPreview && isComposeValid && (
+                <div className="border border-gray-200 rounded-xl overflow-hidden">
+                  <div className="bg-gray-100 px-4 py-2 border-b border-gray-200">
+                    <p className="text-xs text-gray-500">Email Preview</p>
+                    <p className="text-sm font-medium text-gray-700">{newsletterSubject}</p>
+                  </div>
+                  <div className="bg-[#fffdf7] p-4">
+                    {/* Mini preview matching the actual template */}
+                    <div className="max-w-[400px] mx-auto bg-white rounded-xl overflow-hidden shadow-sm">
+                      {/* Header */}
+                      <div className="bg-gradient-to-br from-yellow-500 to-orange-500 p-6 text-center">
+                        <div className="w-12 h-12 bg-white/25 rounded-full mx-auto mb-3 flex items-center justify-center border-2 border-white/40">
+                          <span className="text-2xl">&#x1F41D;</span>
+                        </div>
+                        <h2 className="text-white text-lg font-bold">{newsletterHeading}</h2>
+                        <p className="text-white/80 text-xs mt-1">Busy Bees Indoor Play Center</p>
+                      </div>
+                      {/* Body */}
+                      <div className="p-5">
+                        <p className="text-gray-800 font-semibold text-sm mb-3">
+                          Hi [Subscriber Name]! &#x1F44B;
+                        </p>
+                        <div className="text-gray-600 text-xs leading-relaxed space-y-2">
+                          {newsletterBody.split('\n\n').filter(p => p.trim()).map((paragraph, i) => (
+                            <p key={i}>{paragraph}</p>
+                          ))}
+                        </div>
+                        {newsletterCtaText && newsletterCtaUrl && (
+                          <div className="text-center mt-4">
+                            <span className="inline-block bg-gradient-to-r from-yellow-500 to-orange-500 text-white text-xs font-semibold py-2 px-5 rounded-full">
+                              {newsletterCtaText}
+                            </span>
+                          </div>
+                        )}
+                      </div>
+                      {/* Footer */}
+                      <div className="border-t border-yellow-100 px-5 py-3 text-center">
+                        <p className="text-[10px] text-gray-400">Busy Bees Indoor Play Center &middot; busybeesipc.com</p>
+                        <p className="text-[9px] text-gray-300 mt-1">Unsubscribe</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* Send Test Email */}
+              {isComposeValid && (
+                <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+                  <label className="block text-sm font-medium text-blue-800 mb-2">
+                    &#x1F9EA; Send Test Email
+                  </label>
+                  <p className="text-xs text-blue-600 mb-3">
+                    Send a test version to yourself before sending to all subscribers. Subject will be prefixed with [TEST].
+                  </p>
+                  <div className="flex items-center space-x-2">
+                    <input
+                      type="email"
+                      value={testEmail}
+                      onChange={(e) => {
+                        setTestEmail(e.target.value);
+                        setTestResult(null);
+                      }}
+                      placeholder="Enter your email address"
+                      className="flex-1 px-3 py-2 border border-blue-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                    />
+                    <Button
+                      onClick={handleSendTestNewsletter}
+                      size="sm"
+                      variant="outline"
+                      disabled={!testEmail || testSending}
+                      className="whitespace-nowrap border-blue-300 text-blue-700 hover:bg-blue-100"
+                    >
+                      {testSending ? 'Sending...' : '&#x1F4E8; Send Test'}
+                    </Button>
+                  </div>
+                  {testResult && (
+                    <p className={`text-sm mt-2 ${testResult.success ? 'text-green-700' : 'text-red-700'}`}>
+                      {testResult.success ? '&#x2705;' : '&#x274C;'} {testResult.message}
+                    </p>
+                  )}
+                </div>
+              )}
+
+              {/* Send Result */}
+              {newsletterSendResult && (
+                <div className={`rounded-lg p-4 ${
+                  newsletterSendResult.success
+                    ? 'bg-green-50 border border-green-200'
+                    : 'bg-red-50 border border-red-200'
+                }`}>
+                  {newsletterSendResult.success ? (
+                    <div>
+                      <p className="font-semibold text-green-800">
+                        &#x2705; Newsletter sent successfully!
+                      </p>
+                      <p className="text-sm text-green-700 mt-1">
+                        Sent to {newsletterSendResult.sent} of {newsletterSendResult.total} subscribers.
+                        {newsletterSendResult.failed > 0 && (
+                          <span className="text-orange-600">
+                            {' '}{newsletterSendResult.failed} failed to deliver.
+                          </span>
+                        )}
+                      </p>
+                    </div>
+                  ) : (
+                    <div>
+                      <p className="font-semibold text-red-800">
+                        &#x274C; Failed to send newsletter
+                      </p>
+                      <p className="text-sm text-red-700 mt-1">
+                        Please check the email configuration and try again.
+                      </p>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Action Buttons */}
+              <div className="flex items-center justify-between pt-2 border-t border-gray-100">
+                <Button
+                  onClick={resetComposeForm}
+                  size="sm"
+                  variant="outline"
+                  disabled={newsletterSending}
+                >
+                  Cancel
+                </Button>
+                <div className="flex items-center space-x-3">
+                  {confirmSend && (
+                    <span className="text-sm text-orange-600 font-medium animate-pulse">
+                      Click again to confirm sending to {newsletterStats.active} subscribers
+                    </span>
+                  )}
+                  <Button
+                    onClick={handleSendNewsletter}
+                    size="sm"
+                    disabled={!isComposeValid || newsletterSending || newsletterStats.active === 0}
+                    className={confirmSend ? 'bg-orange-500 hover:bg-orange-600' : ''}
+                  >
+                    {newsletterSending
+                      ? '&#x1F4E8; Sending...'
+                      : confirmSend
+                        ? `&#x2705; Confirm Send to ${newsletterStats.active}`
+                        : `&#x1F4E8; Send to ${newsletterStats.active} Subscribers`
+                    }
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
+        </Card>
+
         {/* Subscriber List */}
         <Card className="p-6">
           <div className="flex items-center justify-between mb-4">
@@ -3425,7 +3829,7 @@ export function AdminPanel({
                 variant="outline"
                 disabled={newsletterLoading}
               >
-                🔄 Refresh
+                &#x1F504; Refresh
               </Button>
             </div>
           </div>
@@ -3436,7 +3840,7 @@ export function AdminPanel({
             </div>
           ) : filteredSubscribers.length === 0 ? (
             <div className="text-center py-8">
-              <p className="text-gray-500 text-lg mb-2">📧 No subscribers yet</p>
+              <p className="text-gray-500 text-lg mb-2">&#x1F4E7; No subscribers yet</p>
               <p className="text-sm text-gray-400">
                 Newsletter signups from the website footer will appear here
               </p>
@@ -3555,7 +3959,7 @@ export function AdminPanel({
             size="sm"
             variant="outline"
           >
-            📥 Export Active Subscribers (CSV)
+            &#x1F4E5; Export Active Subscribers (CSV)
           </Button>
         </Card>
       </div>

--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -1517,6 +1517,169 @@ ${siteUrl}
 }
 
 /**
+ * Send a newsletter email to a single subscriber
+ * Used by the bulk send endpoint to send to each active subscriber
+ */
+export async function sendNewsletterEmail(data: {
+  to: string;
+  subscriberName: string;
+  subject: string;
+  heading: string;
+  body: string;
+  ctaText?: string;
+  ctaUrl?: string;
+  subscriberEmail: string;
+}): Promise<EmailResult> {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://busybeesipc.com';
+  const unsubscribeUrl = `${siteUrl}/newsletter/unsubscribe?email=${encodeURIComponent(data.subscriberEmail)}`;
+
+  // Convert newlines in body to HTML paragraphs
+  const bodyHtml = data.body
+    .split('\n\n')
+    .map(paragraph => paragraph.trim())
+    .filter(paragraph => paragraph.length > 0)
+    .map(paragraph => `<p style="margin: 0 0 16px; font-size: 15px; color: #4b5563; line-height: 1.7;">${paragraph.replace(/\n/g, '<br>')}</p>`)
+    .join('');
+
+  // Plain text fallback
+  const text = `
+${data.heading}
+
+Hi ${data.subscriberName}!
+
+${data.body}
+
+${data.ctaText && data.ctaUrl ? `${data.ctaText}: ${data.ctaUrl}\n` : ''}
+---
+Busy Bees Indoor Play Center
+${siteUrl}
+
+To unsubscribe from our newsletter: ${unsubscribeUrl}
+`;
+
+  // Beautiful on-brand HTML newsletter template
+  const html = `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${data.subject}</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #fffdf7;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #fffdf7; padding: 20px 0;">
+    <tr>
+      <td align="center">
+        <table width="100%" cellpadding="0" cellspacing="0" style="max-width: 600px; background-color: #ffffff; border-radius: 16px; overflow: hidden; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.07);">
+
+          <!-- Header with honeycomb gradient -->
+          <tr>
+            <td style="background: linear-gradient(135deg, #f59e0b 0%, #f97316 50%, #fbbf24 100%); padding: 40px 30px; text-align: center;">
+              <!-- Decorative bees -->
+              <div style="margin-bottom: 8px;">
+                <span style="font-size: 18px; opacity: 0.7;">&#x2728;</span>
+                <span style="font-size: 14px; opacity: 0.5;">&nbsp;</span>
+                <span style="font-size: 22px; opacity: 0.8;">&#x2728;</span>
+              </div>
+              <!-- Bee Logo Circle -->
+              <div style="width: 80px; height: 80px; background-color: rgba(255,255,255,0.25); border-radius: 50%; margin: 0 auto 18px; line-height: 80px; border: 3px solid rgba(255,255,255,0.4);">
+                <span style="font-size: 40px;">&#x1F41D;</span>
+              </div>
+              <h1 style="margin: 0 0 8px; color: #ffffff; font-size: 28px; font-weight: 700; text-shadow: 0 2px 4px rgba(0,0,0,0.15); line-height: 1.3;">
+                ${data.heading}
+              </h1>
+              <p style="margin: 0; color: rgba(255,255,255,0.9); font-size: 14px; letter-spacing: 0.5px;">
+                Busy Bees Indoor Play Center
+              </p>
+            </td>
+          </tr>
+
+          <!-- Body content -->
+          <tr>
+            <td style="padding: 35px 30px 20px;">
+
+              <!-- Greeting -->
+              <p style="margin: 0 0 20px; font-size: 17px; font-weight: 600; color: #1f2937;">
+                Hi ${data.subscriberName}! &#x1F44B;
+              </p>
+
+              <!-- Newsletter Body Content -->
+              <div style="margin-bottom: 25px;">
+                ${bodyHtml}
+              </div>
+
+              ${data.ctaText && data.ctaUrl ? `
+              <!-- CTA Button -->
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center" style="padding: 10px 0 30px;">
+                    <a href="${data.ctaUrl}" style="display: inline-block; background: linear-gradient(135deg, #f59e0b 0%, #f97316 100%); color: #ffffff; font-size: 16px; font-weight: 600; text-decoration: none; padding: 14px 36px; border-radius: 30px; box-shadow: 0 4px 12px rgba(245, 158, 11, 0.4);">
+                      ${data.ctaText}
+                    </a>
+                  </td>
+                </tr>
+              </table>
+              ` : ''}
+
+            </td>
+          </tr>
+
+          <!-- Honeycomb divider -->
+          <tr>
+            <td style="padding: 0 30px;">
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="border-top: 2px solid #fef3c7;"></td>
+                  <td style="width: 60px; text-align: center; padding: 0 10px;">
+                    <span style="font-size: 20px;">&#x1F41D;</span>
+                  </td>
+                  <td style="border-top: 2px solid #fef3c7;"></td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="padding: 25px 30px 30px;">
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center">
+                    <p style="margin: 0 0 8px; font-size: 14px; color: #6b7280;">
+                      &#x1F4CD; Busy Bees Indoor Play Center
+                    </p>
+                    <p style="margin: 0 0 8px; font-size: 14px; color: #6b7280;">
+                      &#x1F310; <a href="${siteUrl}" style="color: #f59e0b; text-decoration: none; font-weight: 500;">busybeesipc.com</a>
+                    </p>
+                    <p style="margin: 0 0 15px; font-size: 13px; color: #9ca3af;">
+                      Thank you for being part of our Busy Bees family! &#x1F49B;
+                    </p>
+                    <p style="margin: 0; font-size: 11px; color: #d1d5db;">
+                      <a href="${unsubscribeUrl}" style="color: #d1d5db; text-decoration: underline;">Unsubscribe</a> from our newsletter
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>
+`;
+
+  return sendEmail({
+    to: data.to,
+    subject: data.subject,
+    text,
+    html,
+  });
+}
+
+/**
  * Send gift card redeemed notification to purchaser
  */
 export async function sendGiftCardRedeemedEmail(data: {


### PR DESCRIPTION
- Add sendNewsletterEmail() with on-brand HTML template featuring
  honeycomb gradient header, configurable content, CTA button, and
  unsubscribe link
- Create POST /api/newsletter/send for bulk sending to all active
  subscribers with rate-limit-safe delays
- Create POST /api/newsletter/test for sending test emails to a
  single address with [TEST] subject prefix
- Create POST /api/newsletter/unsubscribe API and /newsletter/unsubscribe
  page for one-click unsubscribe from email links
- Add compose newsletter UI to admin dashboard Newsletter section with
  subject, heading, body, optional CTA button fields
- Add live email preview in compose form
- Add test send feature to preview newsletter in inbox before bulk send
- Add two-click confirmation for sending to all subscribers

Closes #206

https://claude.ai/code/session_01E7UWUnLneMSSa672c94rin