### PR TITLE
🔒 Update admin PIN in PhoneLogin component to 0297

### DIFF
--- a/src/components/pos/PhoneLogin.tsx
+++ b/src/components/pos/PhoneLogin.tsx
@@ -381,7 +381,7 @@ export function PhoneLogin({ customers, onLogin, onNewCustomer, onAdminAccess }:
 
   const handleAdminPasswordSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (adminPassword === '1234') {
+    if (adminPassword === '0297') {
       setShowAdminModal(false);
       setAdminPassword('');
       setAdminError('');


### PR DESCRIPTION
The hardcoded admin password check in PhoneLogin was still using 1234, causing login to accept the old PIN.

Resolves #211

https://claude.ai/code/session_016wbjiCkANCpzqa9emc4m3a