### PR TITLE
🐛 Fix newsletter emails not sending through Resend

### DIFF
--- a/src/app/api/newsletter/config/route.ts
+++ b/src/app/api/newsletter/config/route.ts
@@ -1,0 +1,16 @@
+/**
+ * API Route: Newsletter Email Config Check
+ * GET - Check if Resend email service is properly configured
+ */
+
+import { NextResponse } from 'next/server';
+import { isEmailServiceConfigured } from '@/lib/email/resend';
+
+export async function GET() {
+  const configured = isEmailServiceConfigured();
+
+  return NextResponse.json({
+    emailConfigured: configured,
+    fromEmail: process.env.RESEND_FROM_EMAIL || 'Busy Bees Indoor Play Center <noreply@busybeesipc.com>',
+  });
+}

--- a/src/app/api/newsletter/send/route.ts
+++ b/src/app/api/newsletter/send/route.ts
@@ -5,7 +5,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/lib/supabase/server';
-import { sendNewsletterEmail } from '@/lib/email/resend';
+import { sendNewsletterEmail, isEmailServiceConfigured } from '@/lib/email/resend';
 import { logger } from '@/lib/logger';
 import { z } from 'zod';
 
@@ -38,6 +38,15 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { error: 'Both button text and URL must be provided together' },
         { status: 400 }
+      );
+    }
+
+    // Verify email service is configured before attempting to send
+    if (!isEmailServiceConfigured()) {
+      logger.error('Newsletter send attempted but RESEND_API_KEY is not configured');
+      return NextResponse.json(
+        { error: 'Email service not configured. RESEND_API_KEY environment variable is missing.' },
+        { status: 503 }
       );
     }
 

--- a/src/app/api/newsletter/test/route.ts
+++ b/src/app/api/newsletter/test/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { sendNewsletterEmail } from '@/lib/email/resend';
+import { sendNewsletterEmail, isEmailServiceConfigured } from '@/lib/email/resend';
 import { logger } from '@/lib/logger';
 import { z } from 'zod';
 
@@ -31,6 +31,15 @@ export async function POST(request: NextRequest) {
     }
 
     const { testEmail, subject, heading, body: bodyContent, ctaText, ctaUrl } = validationResult.data;
+
+    // Verify email service is configured before attempting to send
+    if (!isEmailServiceConfigured()) {
+      logger.error('Test newsletter send attempted but RESEND_API_KEY is not configured');
+      return NextResponse.json(
+        { error: 'Email service not configured. RESEND_API_KEY environment variable is missing.' },
+        { status: 503 }
+      );
+    }
 
     logger.info(
       { testEmail, subject },

--- a/src/components/pos/AdminPanel.tsx
+++ b/src/components/pos/AdminPanel.tsx
@@ -324,6 +324,7 @@ export function AdminPanel({
   const [testEmail, setTestEmail] = useState('');
   const [testSending, setTestSending] = useState(false);
   const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null);
+  const [emailConfigured, setEmailConfigured] = useState<boolean | null>(null);
 
   // Customer loading state
   const [customersLoading, setCustomersLoading] = useState(false);
@@ -368,9 +369,22 @@ export function AdminPanel({
     }
   };
 
+  const checkEmailConfig = async () => {
+    try {
+      const response = await fetch('/api/newsletter/config');
+      if (response.ok) {
+        const data = await response.json();
+        setEmailConfigured(data.emailConfigured);
+      }
+    } catch {
+      setEmailConfigured(false);
+    }
+  };
+
   useEffect(() => {
     if (currentView === 'newsletter') {
       fetchNewsletterSubscribers();
+      checkEmailConfig();
     }
   }, [currentView]);
 
@@ -3517,6 +3531,19 @@ export function AdminPanel({
 
     return (
       <div className="space-y-6">
+        {/* Email Config Warning */}
+        {emailConfigured === false && (
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+            <p className="text-red-800 font-medium">
+              &#x26A0;&#xFE0F; Email service not configured
+            </p>
+            <p className="text-red-600 text-sm mt-1">
+              RESEND_API_KEY environment variable is missing. Newsletter emails will not be delivered until this is set.
+              Add your Resend API key to your environment variables to enable email sending.
+            </p>
+          </div>
+        )}
+
         {/* Stats Cards */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <Card className="p-4">

--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -10,7 +10,8 @@ import { parseDateString } from '@/lib/utils';
 
 // Business email addresses
 const BUSINESS_EMAIL = 'info@busybeesipc.com';
-const FROM_EMAIL = process.env.RESEND_FROM_EMAIL || 'noreply@busybeesipc.com';
+const DEFAULT_FROM_EMAIL = 'Busy Bees Indoor Play Center <noreply@busybeesipc.com>';
+const FROM_EMAIL = process.env.RESEND_FROM_EMAIL || DEFAULT_FROM_EMAIL;
 
 // Lazy-initialize Resend client to prevent crashes when API key is missing
 let resendClient: Resend | null = null;
@@ -31,6 +32,7 @@ interface SendEmailOptions {
   text: string;
   html?: string;
   replyTo?: string;
+  headers?: Record<string, string>;
 }
 
 interface EmailResult {
@@ -40,10 +42,17 @@ interface EmailResult {
 }
 
 /**
+ * Check if the email service (Resend) is properly configured
+ */
+export function isEmailServiceConfigured(): boolean {
+  return !!process.env.RESEND_API_KEY;
+}
+
+/**
  * Send an email using Resend
  */
 export async function sendEmail(options: SendEmailOptions): Promise<EmailResult> {
-  const { to, subject, text, html, replyTo } = options;
+  const { to, subject, text, html, replyTo, headers } = options;
 
   // Get lazy-initialized client (returns null if API key is missing)
   const resend = getResendClient();
@@ -54,12 +63,10 @@ export async function sendEmail(options: SendEmailOptions): Promise<EmailResult>
       { to, subject },
       'RESEND_API_KEY not configured - email not sent'
     );
-    // Return success in development to allow form testing
     if (process.env.NODE_ENV === 'development') {
-      logger.info({ to, subject, text }, '📧 Development mode - email would be sent');
-      return { success: true, messageId: 'dev-mode' };
+      logger.info({ to, subject }, '📧 Development mode - email would be sent (RESEND_API_KEY not set)');
     }
-    return { success: false, error: 'Email service not configured' };
+    return { success: false, error: 'Email service not configured. Set RESEND_API_KEY environment variable.' };
   }
 
   try {
@@ -70,6 +77,7 @@ export async function sendEmail(options: SendEmailOptions): Promise<EmailResult>
       text,
       html,
       replyTo,
+      headers,
     });
 
     if (error) {
@@ -1676,6 +1684,10 @@ To unsubscribe from our newsletter: ${unsubscribeUrl}
     subject: data.subject,
     text,
     html,
+    headers: {
+      'List-Unsubscribe': `<${unsubscribeUrl}>`,
+      'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+    },
   });
 }
 


### PR DESCRIPTION
- Fix FROM_EMAIL to include display name for proper Resend delivery
- Remove dev-mode silent success that masked missing RESEND_API_KEY
  (previously returned success:true with no email sent in development)
- Add List-Unsubscribe headers to newsletter emails for Gmail/Yahoo
  deliverability compliance
- Add email config check endpoint (/api/newsletter/config) and
  pre-send validation in send/test routes with clear error messages
- Add admin panel warning banner when RESEND_API_KEY is not configured

https://claude.ai/code/session_01GqQkEcqozKaPvjjfTHWCUH