### PR TITLE
🐛 Fix admin PIN not updating in database

### DIFF
--- a/supabase/migrations/026_update_staff_pin.sql
+++ b/supabase/migrations/026_update_staff_pin.sql
@@ -1,0 +1,9 @@
+-- Update staff PIN to 0297
+-- The original migration (004) used ON CONFLICT DO NOTHING, so changing
+-- the default value in that file had no effect on existing databases.
+-- This migration explicitly updates the PIN for databases that still
+-- have the old default value.
+
+UPDATE public.settings
+SET value = '0297', updated_at = NOW()
+WHERE key = 'staff_pin' AND value = '1234';


### PR DESCRIPTION
The previous PIN change (ac533d7) modified the migration file's INSERT
default from 1234 to 0297, but since migration 004 had already run in
production with ON CONFLICT DO NOTHING, the database value was never
updated. This new migration explicitly updates the staff_pin setting
for databases still using the old default.

Resolves #224

https://claude.ai/code/session_01Q8hrRsuWkuBsHDvUp721ME