### PR TITLE
✨ Email business on website After Dark bookings

### DIFF
--- a/src/app/api/after-dark/book/route.ts
+++ b/src/app/api/after-dark/book/route.ts
@@ -6,6 +6,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/lib/supabase/server';
 import { logger } from '@/lib/logger';
+import { sendAfterDarkBookingEmail } from '@/lib/email/resend';
 import { z } from 'zod';
 
 const MAX_KIDS = 40;
@@ -81,6 +82,32 @@ export async function POST(request: NextRequest) {
     }
 
     logger.info({ bookingId: data.id, event_date, num_kids }, 'After Dark booking created');
+
+    // Notify the business of the new booking. Non-blocking: a failed
+    // notification must never prevent a confirmed booking from succeeding.
+    try {
+      const emailResult = await sendAfterDarkBookingEmail({
+        eventDate: parsed.data.event_date,
+        parentName: parsed.data.parent_name,
+        parentEmail: parsed.data.parent_email,
+        parentPhone: parsed.data.parent_phone,
+        numKids: parsed.data.num_kids,
+        kidDetails: parsed.data.kid_details,
+        notes: parsed.data.notes,
+        remainingSpots: remaining - num_kids,
+      });
+      if (!emailResult.success) {
+        logger.error(
+          { error: emailResult.error, bookingId: data.id },
+          'Failed to send After Dark booking notification email'
+        );
+      }
+    } catch (emailError) {
+      logger.error(
+        { error: emailError, bookingId: data.id },
+        'After Dark booking notification email threw'
+      );
+    }
 
     return NextResponse.json({
       booking: data,

--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -260,6 +260,50 @@ Submitted at: ${new Date().toLocaleString()}
 }
 
 /**
+ * Send After Dark booking notification to business email
+ */
+export async function sendAfterDarkBookingEmail(data: {
+  eventDate: string;
+  parentName: string;
+  parentEmail: string;
+  parentPhone: string;
+  numKids: number;
+  kidDetails?: string | null;
+  notes?: string | null;
+  remainingSpots?: number;
+}): Promise<EmailResult> {
+  const subject = `New After Dark Booking - ${data.eventDate} (${data.numKids} kid${data.numKids === 1 ? '' : 's'})`;
+  const text = `
+New After Dark booking from the Busy Bees website:
+
+BOOKING DETAILS:
+Event Date: ${data.eventDate}
+Number of Kids: ${data.numKids}
+Kid Details: ${data.kidDetails?.trim() || 'None provided'}
+${typeof data.remainingSpots === 'number' ? `Spots Remaining After This Booking: ${data.remainingSpots}` : ''}
+
+CONTACT INFORMATION:
+Parent Name: ${data.parentName}
+Email: ${data.parentEmail}
+Phone: ${data.parentPhone}
+
+NOTES:
+${data.notes?.trim() || 'None provided'}
+
+---
+Sent from Busy Bees Indoor Play Center website
+Booked at: ${new Date().toLocaleString()}
+`;
+
+  return sendEmail({
+    to: BUSINESS_EMAIL,
+    subject,
+    text,
+    replyTo: data.parentEmail,
+  });
+}
+
+/**
  * Send gift card to recipient
  */
 export async function sendGiftCardEmail(data: {


### PR DESCRIPTION
Notify info@busybeesipc.com whenever a customer books an After Dark slot through the website. Mirrors the existing party-booking business notification pattern (BUSINESS_EMAIL + sendEmail helper).

The notification is non-blocking: if the email fails to send, the booking still succeeds and the failure is logged server-side.

Scope is the public website route only (api/after-dark/book); POS staff bookings are intentionally excluded.