### PR TITLE
✨ Show customer gift card credit on POS lookup

### DIFF
--- a/src/app/api/pos/customers/route.ts
+++ b/src/app/api/pos/customers/route.ts
@@ -252,6 +252,7 @@ export async function GET() {
         purchases: purchasesByCustomer.get(user.id) || [],
         activeSessions: userSessions,
         savedCards: [], // Payment methods would need a separate fetch if needed
+        giftCardBalance: Number(user.gift_card_balance) || 0, // Account credit from redeemed gift cards
         createdAt: user.created_at,
         lastVisit: user.last_login,
       };

--- a/src/app/pos/page.tsx
+++ b/src/app/pos/page.tsx
@@ -50,6 +50,7 @@ interface Customer {
     purchases: Purchase[];
     activeSessions: Session[];
     savedCards: SavedCard[];
+    giftCardBalance?: number; // Account credit from redeemed gift cards
     createdAt: string;
     lastVisit?: string;
 }

--- a/src/components/pos/CheckIn.tsx
+++ b/src/components/pos/CheckIn.tsx
@@ -41,6 +41,7 @@ interface Customer {
     purchases: Purchase[];
     activeSessions: Session[];
     savedCards: SavedCard[];
+    giftCardBalance?: number; // Account credit from redeemed gift cards
     createdAt: string;
     lastVisit?: string;
 }
@@ -2256,6 +2257,12 @@ export function CheckIn({
                                 ✅ Found: <strong>{selectedCustomer.name}</strong> -{" "}
                                 {formatPhoneNumber(selectedCustomer.phone)}
                             </p>
+                            {(selectedCustomer.giftCardBalance || 0) > 0 && (
+                                <p className="mt-2 inline-flex items-center gap-1 rounded-full bg-yellow-100 border border-yellow-300 px-3 py-1 text-sm font-semibold text-yellow-800">
+                                    🎁 Gift card credit: {formatCurrency(selectedCustomer.giftCardBalance || 0)}
+                                    <span className="font-normal text-yellow-700">— applies automatically at checkout</span>
+                                </p>
+                            )}
                         </div>
                     )}
 

--- a/src/components/pos/CustomerDashboard.tsx
+++ b/src/components/pos/CustomerDashboard.tsx
@@ -39,6 +39,7 @@ interface Customer {
   purchases: Purchase[];
   activeSessions: Session[]; // Multiple active sessions for different passes
   savedCards: SavedCard[];
+  giftCardBalance?: number; // Account credit from redeemed gift cards
   createdAt: string;
   lastVisit?: string;
 }


### PR DESCRIPTION
When staff look up a customer by phone at the POS, the screen never surfaced the customer's account credit — the only balance endpoint (`/api/gift-cards/balance`) returns the *authenticated* user's balance, so it can't show a staff-looked-up customer's credit.

Thread `gift_card_balance` through the lookup instead:
- `/api/pos/customers` now returns `giftCardBalance` per customer
- Add the field to the POS `Customer` type (page, CheckIn, CustomerDashboard)
- CheckIn's "Found" result now shows a "🎁 Gift card credit: $X — applies automatically at checkout" badge when the customer has a balance

Pairs with the kiosk/POS credit-application fixes so staff can both see the credit on lookup and watch it apply at checkout.